### PR TITLE
Support run multiple games with seperated category

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -55,6 +55,8 @@ async def on_ready():
     for guild in client.guilds:
         print("Connected to server: ", guild.name, " ServerID: ", guild.id)
         await admin.create_category(guild, client.user, config.GAME_CATEGORY)  # Create GAME_CATEGORY if not existing
+        await admin.create_channel(guild, client.user, config.LOBBY_CHANNEL, is_public=True)
+        await admin.create_channel(guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
         # game_list.add_game(guild.id,Game(guild, interface.ConsoleInterface(guild)))
         game_list.add_game(guild.id, Game(guild, interface.DiscordInterface(guild, client)))
 

--- a/bot.py
+++ b/bot.py
@@ -18,13 +18,6 @@ async def process_message(client, message):
 
 def verify_ok(message):
     return True
-    try:
-        if message.channel.category.name == config.GAME_CATEGORY:
-            return True
-        else:
-            return False
-    except:  # Command not in Category channel
-        return False
 
 
 # ============ Test Discord server =======
@@ -69,7 +62,6 @@ async def on_ready():
 
 @client.event
 async def on_message(message):
-    # Bot only replies on the channels belong to config.GAME_CATEGORY
     if verify_ok(message):
         await process_message(client, message)  # loop through all commands and do action on first command that match
 

--- a/bot.py
+++ b/bot.py
@@ -10,13 +10,14 @@ if not config.DISCORD_TOKEN:
 # ============ Local functions ============
 
 
-async def process_message(message):
+async def process_message(client, message):
     if message.content.strip().startswith(config.BOT_PREFIX):
         game = game_list.get_game(message.guild.id)
-        await command.parse_command(game, message)
+        await command.parse_command(client, game, message)
 
 
 def verify_ok(message):
+    return True
     try:
         if message.channel.category.name == config.GAME_CATEGORY:
             return True
@@ -70,7 +71,7 @@ async def on_ready():
 async def on_message(message):
     # Bot only replies on the channels belong to config.GAME_CATEGORY
     if verify_ok(message):
-        await process_message(message)  # loop through all commands and do action on first command that match
+        await process_message(client, message)  # loop through all commands and do action on first command that match
 
 
 client.run(config.DISCORD_TOKEN)

--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,5 @@
 import discord
-from commands import command
+from commands import command, admin
 from game import *
 import config
 import interface
@@ -16,9 +16,14 @@ async def process_message(message):
         await command.parse_command(game, message)
 
 
-def verify_ok(user):
-    # TODO: Check valid user in valid channel
-    return True
+def verify_ok(message):
+    try:
+        if message.channel.category.name == config.GAME_CATEGORY:
+            return True
+        else:
+            return False
+    except:  # Command not in Category channel
+        return False
 
 
 # ============ Test Discord server =======
@@ -49,6 +54,7 @@ async def on_ready():
     print("=========================BOT STARTUP=========================")
     for guild in client.guilds:
         print("Connected to server: ", guild.name, " ServerID: ", guild.id)
+        await admin.create_category(guild, client.user, config.GAME_CATEGORY)  # Create GAME_CATEGORY if not existing
         # game_list.add_game(guild.id,Game(guild, interface.ConsoleInterface(guild)))
         game_list.add_game(guild.id, Game(guild, interface.DiscordInterface(guild, client)))
 
@@ -60,8 +66,8 @@ async def on_ready():
 
 @client.event
 async def on_message(message):
-    # Check valid author
-    if verify_ok(message.author):
+    # Bot only replies on the channels belong to config.GAME_CATEGORY
+    if verify_ok(message):
         await process_message(message)  # loop through all commands and do action on first command that match
 
 

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -24,7 +24,7 @@ def is_admin(author):
     if admin_role in author.guild.roles:
         return True
     else:
-        print(f"{author.display_name} is not Admin Role")
+        # print(f"{author.display_name} is not Admin Role")
         return False
 
 

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -8,6 +8,15 @@ import asyncio
 from utils import logger
 import config
 
+def is_valid_category(message):
+    try:  # Channel may not belong to any category, make message.channel.category empty
+        if message.channel.category.name == config.GAME_CATEGORY:
+            return True
+        else:
+            return False
+    except:  # Command not in Category channel
+        return False
+
 
 def is_admin(author):
     # Check if this user has 'Admin' right
@@ -46,8 +55,24 @@ async def create_category(guild, author, category_name):
             await create_channel(guild, author, config.GAMEPLAY_CHANNEL, is_public=False)
             return category
         except Exception as e:
-            print(e);raise
+            print("Exception at #", category_name, author)
+            logger.logger_debug(guild.categories)
+            print(e)
     return existing_category
+
+
+async def delete_category(guild, author, category_name=config.GAME_CATEGORY):
+    # Delete category. Any Admin can delete it
+    try:
+        category = discord.utils.get(guild.categories, name=category_name)
+        assert isinstance(category, discord.CategoryChannel)
+        response = f"{author.display_name} deleted channel {category_name}"
+        print(response)
+        await category.delete()
+    except Exception as e:
+        print("Exception at #", category_name, author)
+        logger.logger_debug(guild.categories)
+        print(e)
 
 
 async def create_channel(guild, author, channel_name, is_public=False):
@@ -70,7 +95,9 @@ async def create_channel(guild, author, channel_name, is_public=False):
             await channel.send(response)
             return channel
         except Exception as e:
-            print(e);raise
+            print("Exception at #", channel_name, author)
+            logger.logger_debug(guild.channels)
+            print(e)
     return existing_channel
 
 
@@ -85,9 +112,9 @@ async def delete_channel(guild, author, channel_name):
         # await channel.send(response)
         await channel.delete()
     except Exception as e:
-        print(channel_name, author)
+        print("Exception at #", channel_name, author)
         logger.logger_debug(guild.channels)
-        print(e);raise
+        print(e)
 
 
 async def add_user_to_channel(guild, user, channel_name, is_read=True, is_send=True):

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -10,10 +10,7 @@ import config
 
 def is_valid_category(message):
     try:  # Channel may not belong to any category, make message.channel.category empty
-        if message.channel.category.name == config.GAME_CATEGORY:
-            return True
-        else:
-            return False
+        return message.channel.category.name == config.GAME_CATEGORY
     except:  # Command not in Category channel
         return False
 

--- a/commands/command.py
+++ b/commands/command.py
@@ -98,19 +98,29 @@ async def parse_command(client, game, message):
         elif cmd == 'fdelete_channel':  # Test only
             await admin.delete_channel(message.guild, client.user, parameters[0])
         elif cmd == 'fcreate':  # Create game channels
-            await admin.create_category(message.guild, client.user, config.GAME_CATEGORY)
-            await admin.create_channel(message.guild, client.user, config.LOBBY_CHANNEL, is_public=True)
-            await admin.create_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
+            if len(message.mentions) == 1:
+                user = message.mentions[0]
+                if user.id == client.user.id:
+                    await admin.create_category(message.guild, client.user, config.GAME_CATEGORY)
+                    await admin.create_channel(message.guild, client.user, config.LOBBY_CHANNEL, is_public=True)
+                    await admin.create_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
+            else:
+                await message.reply("Missing @bot_name")
         elif cmd == "fdelete":  # Delete all channels and category under config.GAME_CATEGORY
-            try:
-                await admin.delete_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL)
-                await admin.delete_channel(message.guild, client.user, config.WEREWOLF_CHANNEL)
-                await admin.delete_channel(message.guild, client.user, config.CEMETERY_CHANNEL)
-                await admin.delete_all_personal_channel(message.guild)
-                await admin.delete_channel(message.guild, client.user, config.LOBBY_CHANNEL)
-                await admin.delete_category(message.guild, client.user)
-            except Exception as e:
-                print(e)
+            if len(message.mentions) == 1:
+                user = message.mentions[0]
+                try:
+                    if user.id == client.user.id:
+                        await admin.delete_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL)
+                        await admin.delete_channel(message.guild, client.user, config.WEREWOLF_CHANNEL)
+                        await admin.delete_channel(message.guild, client.user, config.CEMETERY_CHANNEL)
+                        await admin.delete_all_personal_channel(message.guild)
+                        await admin.delete_channel(message.guild, client.user, config.LOBBY_CHANNEL)
+                        await admin.delete_category(message.guild, client.user)
+                except Exception as e:
+                    print(e)
+            else:
+                await message.reply("Missing @bot_name")
         elif cmd == 'fadd':  # !add @user1 channel_name
             print(parameters)
             user = message.mentions[0]
@@ -123,7 +133,7 @@ async def parse_command(client, game, message):
             await admin.remove_user_from_channel(message.guild, user, channel_name)
         elif cmd == 'fend':
             await game.stop()
-        if admin.is_valid_category(message):
+        elif admin.is_valid_category(message):
             if cmd == "fjoin":
                 await admin.create_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
                 await player.do_join(game, message, force=True)
@@ -146,8 +156,8 @@ async def parse_command(client, game, message):
             elif cmd == "fdebug":
                 # print(asyncio.all_tasks())
                 exec(" ".join(parameters))
-    else:
-        await message.reply(f"{message.author} is not Admin role or Use invalid command.")
+        else:
+            await message.reply(f"{message.author} used invalid Admin command.")
 
 
 async def test_commands(guild):

--- a/commands/command.py
+++ b/commands/command.py
@@ -6,99 +6,111 @@ import discord
 import asyncio
 
 
-async def parse_command(game, message):
+async def parse_command(client, game, message):
     message_parts = message.content.strip()[len(config.BOT_PREFIX):].split(" ")
     cmd, parameters = message_parts[0], message_parts[1:]
-    # Game commands
-    if cmd == 'join':
-        await player.do_join(game, message, force=False)
-    elif cmd == 'leave':
-        await player.do_leave(game, message, force=False)
-    elif cmd == 'start':
-        await player.do_start(game, message, force=False)
-    elif cmd == 'next':  # Next phase
-        await player.do_next(game, message, force=False)
-    elif cmd == 'stop':
-        await player.do_stop(game, message, force=False)
+    # Game commands only valid under GAME CATEGORY:
+    if admin.is_valid_category(message):
+        if cmd == 'join':
+            await player.do_join(game, message, force=False)
+        elif cmd == 'leave':
+            await player.do_leave(game, message, force=False)
+        elif cmd == 'start':
+            await player.do_start(game, message, force=False)
+        elif cmd == 'next':  # Next phase
+            await player.do_next(game, message, force=False)
+        elif cmd == 'stop':
+            await player.do_stop(game, message, force=False)
 
-    elif cmd in ['vote', 'kill', 'guard', 'seer']:
-        is_valid_channel = (cmd == 'vote' and message.channel.name == config.GAMEPLAY_CHANNEL) or\
-            (cmd == 'kill' and message.channel.name == config.WEREWOLF_CHANNEL) or True
-        # TODO: check if cmd guard/seer in the author's personal channel
+        elif cmd in ['vote', 'kill', 'guard', 'seer']:
+            is_valid_channel = (cmd == 'vote' and message.channel.name == config.GAMEPLAY_CHANNEL) or\
+                (cmd == 'kill' and message.channel.name == config.WEREWOLF_CHANNEL) or True
+            # TODO: check if cmd guard/seer in the author's personal channel
 
-        if is_valid_channel:
-            author = message.author
-            is_valid_command = False
-            if len(parameters) == 1:
-                if len(message.raw_mentions) == 1:
-                    is_valid_command = True
-                    msg = await game.do_player_action(cmd, author.id, message.raw_mentions[0])
-                    await message.reply(msg)
-
-                elif parameters[0].isdigit():
-                    target_index = int(parameters[0]) - 1
-                    alive_players = game.get_alive_players()
-                    if 0 <= target_index < len(alive_players):
+            if is_valid_channel:
+                author = message.author
+                is_valid_command = False
+                if len(parameters) == 1:
+                    if len(message.raw_mentions) == 1:
                         is_valid_command = True
-                        target_user = alive_players[target_index]
-                        msg = await game.do_player_action(cmd, author.id, target_user.player_id)
+                        msg = await game.do_player_action(cmd, author.id, message.raw_mentions[0])
                         await message.reply(msg)
 
-                if not is_valid_command:
-                    await message.reply(text_template.generate_invalid_command_text(cmd))
+                    elif parameters[0].isdigit():
+                        target_index = int(parameters[0]) - 1
+                        alive_players = game.get_alive_players()
+                        if 0 <= target_index < len(alive_players):
+                            is_valid_command = True
+                            target_user = alive_players[target_index]
+                            msg = await game.do_player_action(cmd, author.id, target_user.player_id)
+                            await message.reply(msg)
 
+                    if not is_valid_command:
+                        await message.reply(text_template.generate_invalid_command_text(cmd))
+
+                else:
+                    await message.reply(text_template.generate_not_vote_1_player_text())
             else:
-                await message.reply(text_template.generate_not_vote_1_player_text())
-        else:
-            if cmd == 'vote':
-                real_channel = f"#{config.GAMEPLAY_CHANNEL}"
-            elif cmd == 'kill':
-                real_channel = f"#{config.WEREWOLF_CHANNEL}"
+                if cmd == 'vote':
+                    real_channel = f"#{config.GAMEPLAY_CHANNEL}"
+                elif cmd == 'kill':
+                    real_channel = f"#{config.WEREWOLF_CHANNEL}"
+                else:
+                    real_channel = "your personal channel"
+
+                await admin.send_text_to_channel(
+                    message.guild, text_template.generate_invalid_channel_text(real_channel), message.channel.name
+                )
+
+        elif cmd == 'status':
+            await player.do_generate_vote_status_table(message.channel, game.get_vote_status())
+
+        elif cmd == 'timer':
+            ''' Usage: 
+                `!timer 60 30 20` -> dayphase=60s, nightphase=30s, alertperiod=20s
+            '''
+            if len(parameters) < 3:
+                timer_phase = [config.DAYTIME, config.NIGHTTIME, config.ALERT_PERIOD]
+                await message.reply(
+                    "Use default settings: " +
+                    f"dayphase={config.DAYTIME}s, nightphase={config.NIGHTTIME}s, alertperiod={config.ALERT_PERIOD}s"
+                )
             else:
-                real_channel = "your personal channel"
+                timer_phase = list(map(int, parameters))
+                await message.reply(
+                    "New settings: " +
+                    f"dayphase={timer_phase[0]}s, nightphase={timer_phase[1]}s, alertperiod={timer_phase[2]}s"
+                )
+            game.set_timer_phase(timer_phase)
 
-            await admin.send_text_to_channel(
-                message.guild, text_template.generate_invalid_channel_text(real_channel), message.channel.name
-            )
+        elif cmd == 'timerstart':
+            game.timer_stopped = False
+            await message.reply(text_template.generate_timer_start_text())
+        elif cmd == 'timerstop':
+            game.timer_stopped = True
+            await message.reply(text_template.generate_timer_stop_text())
 
-    elif cmd == 'status':
-        await player.do_generate_vote_status_table(message.channel, game.get_vote_status())
-
-    elif cmd == 'timer':
-        ''' Usage: 
-            `!timer 60 30 20` -> dayphase=60s, nightphase=30s, alertperiod=20s
-        '''
-        if len(parameters) < 3:
-            timer_phase = [config.DAYTIME, config.NIGHTTIME, config.ALERT_PERIOD]
-            await message.reply(
-                "Use default settings: " +
-                f"dayphase={config.DAYTIME}s, nightphase={config.NIGHTTIME}s, alertperiod={config.ALERT_PERIOD}s"
-            )
-        else:
-            timer_phase = list(map(int, parameters))
-            await message.reply(
-                "New settings: " +
-                f"dayphase={timer_phase[0]}s, nightphase={timer_phase[1]}s, alertperiod={timer_phase[2]}s"
-            )
-        game.set_timer_phase(timer_phase)
-
-    elif cmd == 'timerstart':
-        game.timer_stopped = False
-        await message.reply(text_template.generate_timer_start_text())
-    elif cmd == 'timerstop':
-        game.timer_stopped = True
-        await message.reply(text_template.generate_timer_stop_text())
 
     # Admin/Bot commands - User should not directly use these commands
-    elif admin.is_admin(message.author):
+    if admin.is_admin(message.author):
         if cmd == 'fcreate_channel':  # Test only
-            await admin.create_channel(message.guild, message.author, parameters[0])
+            await admin.create_channel(message.guild, client.user, parameters[0])
         elif cmd == 'fdelete_channel':  # Test only
-            await admin.delete_channel(message.guild, message.author, parameters[0])
+            await admin.delete_channel(message.guild, client.user, parameters[0])
         elif cmd == 'fcreate':  # Create game channels
-            await admin.create_category(message.guild, message.author, config.GAME_CATEGORY)
-            await admin.create_channel(message.guild, message.author, config.LOBBY_CHANNEL, is_public=True)
-            await admin.create_channel(message.guild, message.author, config.GAMEPLAY_CHANNEL, is_public=False)
+            await admin.create_category(message.guild, client.user, config.GAME_CATEGORY)
+            await admin.create_channel(message.guild, client.user, config.LOBBY_CHANNEL, is_public=True)
+            await admin.create_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
+        elif cmd == "fdelete":  # Delete all channels and category under config.GAME_CATEGORY
+            try:
+                await admin.delete_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL)
+                await admin.delete_channel(message.guild, client.user, config.WEREWOLF_CHANNEL)
+                await admin.delete_channel(message.guild, client.user, config.CEMETERY_CHANNEL)
+                await admin.delete_all_personal_channel(message.guild)
+                await admin.delete_channel(message.guild, client.user, config.LOBBY_CHANNEL)
+                await admin.delete_category(message.guild, client.user)
+            except Exception as e:
+                print(e)
         elif cmd == 'fadd':  # !add @user1 channel_name
             print(parameters)
             user = message.mentions[0]
@@ -111,29 +123,31 @@ async def parse_command(game, message):
             await admin.remove_user_from_channel(message.guild, user, channel_name)
         elif cmd == 'fend':
             await game.stop()
-        elif cmd == "fjoin":
-            await admin.create_channel(message.guild, message.author, config.GAMEPLAY_CHANNEL, is_public=False)
-            await player.do_join(game, message, force=True)
-        elif cmd == "fleave":
-            await player.do_leave(game, message, force=True)
-        elif cmd == "fstart":
-            await player.do_start(game, message, force=True)
-        elif cmd == 'fnext':  # Next phase
-            await player.do_next(game, message, force=True)
-        elif cmd == 'fstop':
-            await player.do_stop(game, message, force=True)
-        elif cmd == "fclean":
-            try:
-                await admin.delete_channel(message.guild, message.author, config.GAMEPLAY_CHANNEL)
-                await admin.delete_channel(message.guild, message.author, config.WEREWOLF_CHANNEL)
-                await admin.delete_all_personal_channel(message.guild)
-            except Exception as e:
-                print(e)
-        elif cmd == "fdebug":
-            # print(asyncio.all_tasks())
-            exec(" ".join(parameters))
+        if admin.is_valid_category(message):
+            if cmd == "fjoin":
+                await admin.create_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL, is_public=False)
+                await player.do_join(game, message, force=True)
+            elif cmd == "fleave":
+                await player.do_leave(game, message, force=True)
+            elif cmd == "fstart":
+                await player.do_start(game, message, force=True)
+            elif cmd == 'fnext':  # Next phase
+                await player.do_next(game, message, force=True)
+            elif cmd == 'fstop':
+                await player.do_stop(game, message, force=True)
+            elif cmd == "fclean":  # Delete all private channels under config.GAME_CATEGORY
+                try:
+                    await admin.delete_channel(message.guild, client.user, config.GAMEPLAY_CHANNEL)
+                    await admin.delete_channel(message.guild, client.user, config.WEREWOLF_CHANNEL)
+                    await admin.delete_channel(message.guild, client.user, config.CEMETERY_CHANNEL)
+                    await admin.delete_all_personal_channel(message.guild)
+                except Exception as e:
+                    print(e)
+            elif cmd == "fdebug":
+                # print(asyncio.all_tasks())
+                exec(" ".join(parameters))
     else:
-        await message.reply(f"{message.author} is not Admin role")
+        await message.reply(f"{message.author} is not Admin role or Use invalid command.")
 
 
 async def test_commands(guild):

--- a/commands/player.py
+++ b/commands/player.py
@@ -124,8 +124,8 @@ async def do_stop(game, message, force=False):
                 game.vote_stop.add(message.author.id)
                 valid, text = check_vote_valid(len(game.vote_stop), 1, "stop")
                 if valid:
-                    await game.stop()
                     await message.reply(text_template.generate_game_stop_text())
+                    await game.stop()
                 else:
                     await message.reply(text_template.generate_vote_for_game_text("stop", message.author.display_name, text))
     else:

--- a/config.py
+++ b/config.py
@@ -4,6 +4,7 @@ load_dotenv()
 # ============ Configurations ===========
 # DISCORD_TOKEN in .env file
 DISCORD_TOKEN = os.getenv('DISCORD_TOKEN')
+DISCORD_BOT_NAME = os.getenv('DISCORD_BOT_NAME')
 DISCORD_TESTING_SERVER_ID = int(os.getenv('DISCORD_TESTING_SERVER_ID'))
 DISCORD_DEPLOY_SERVER_ID = int(os.getenv('DISCORD_DEPLOY_SERVER_ID'))
 DISCORD_TESTING_USER1_ID = int(os.getenv('DISCORD_TESTING_USER1_ID'))
@@ -29,7 +30,8 @@ ALERT_PERIOD = 30  # 20s
 GUARD_PREVENT_SELF_PROTECTION = False  # Use True if do not want guard use skill on himself
 
 ''' Non-configurable value '''
-GAME_CATEGORY = "GAME"
+GAME_CATEGORY = os.getenv('GAME_CATEGORY') if os.getenv('GAME_CATEGORY') else "GAME"
+
 LOBBY_CHANNEL = "lobby"
 GAMEPLAY_CHANNEL = "gameplay"
 WEREWOLF_CHANNEL = "werewolf"

--- a/config.py
+++ b/config.py
@@ -22,9 +22,9 @@ else:
 # each !next cmd have at least 60 seconds apart
 NEXT_CMD_DELAY = 30
 VOTE_RATE = 0.5  # 50%
-DAYTIME = 60    # 60s
-NIGHTTIME = 30  # 30s
-ALERT_PERIOD = 20  # 20s
+DAYTIME = 240    # 60s
+NIGHTTIME = 60  # 30s
+ALERT_PERIOD = 30  # 20s
 
 GUARD_PREVENT_SELF_PROTECTION = False  # Use True if do not want guard use skill on himself
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -170,6 +170,7 @@ class Game:
         self.players[id_] = None
         self.playersname[id_] = player_name
         await self.interface.add_user_to_channel(id_, config.GAMEPLAY_CHANNEL, is_read=True, is_send=True)
+        await self.interface.send_text_to_channel(f"Chào <@{id_}>", config.GAMEPLAY_CHANNEL)
         return len(self.players)  # Return number of current players
 
     async def remove_player(self, id_):
@@ -179,6 +180,7 @@ class Game:
         print("Player", id_, "left")
         del self.players[id_]
         del self.playersname[id_]
+        await self.interface.send_text_to_channel(f"Bye <@{id_}>", config.GAMEPLAY_CHANNEL)
         await self.interface.add_user_to_channel(id_, config.GAMEPLAY_CHANNEL, is_read=False, is_send=False)
         return len(self.players)  # Return number of current players
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -261,6 +261,7 @@ class Game:
         # Print werewolf list:
         werewolf_list = ", ".join([str(f"<@{_id}>") for _id, a_player in self.players.items() if isinstance(a_player, roles.Werewolf)])
         await self.interface.send_text_to_channel(f"{werewolf_list} là Sói.", config.GAMEPLAY_CHANNEL)
+        await self.cancel_running_task(self.task_run_timer_phase)
         print("End game loop")
 
     def is_end_game(self):

--- a/game/roles/character.py
+++ b/game/roles/character.py
@@ -36,6 +36,7 @@ class Character:
         # Mute player in config.GAMEPLAY_CHANNEL
         await self.interface.add_user_to_channel(self.player_id, config.GAMEPLAY_CHANNEL, is_read=True, is_send=False)
         await self.interface.add_user_to_channel(self.player_id, config.CEMETERY_CHANNEL, is_read=True, is_send=True)
+        await self.interface.add_user_to_channel(self.player_id, config.WEREWOLF_CHANNEL, is_read=False, is_send=False)
         return True
 
     def get_protected(self):

--- a/interface.py
+++ b/interface.py
@@ -12,9 +12,6 @@ class ConsoleInterface:
     async def send_embed_to_channel(self, embed_msg, channel_name):
         print(f"#{channel_name}: {embed_msg}")
 
-    async def create_category(self, category_name):
-        print(f"#{category_name} created!")
-
     async def create_channel(self, channel_name):
         print(f"{channel_name} created!")
 
@@ -35,9 +32,6 @@ class DiscordInterface:
 
     async def send_embed_to_channel(self, embed_msg, channel_name):
         await commands.admin.send_embed_to_channel(self.guild, embed_msg, channel_name)
-
-    async def create_category(self, category_name):
-        await commands.admin.create_category(self.guild, self.client.user, category_name)
 
     async def create_channel(self, channel_name):
         await commands.admin.create_channel(self.guild, self.client.user, channel_name)


### PR DESCRIPTION
We can have 1 or 2 bot running on separated Category 
```
--GAME                   --> short game
     |-- #lobby
     |-- #gameplay
--GAME_DAILY             --> long game for realtime play
     |-- #lobby
     |-- #gameplay
```
Currently only need to change `GAME_CATEGORY = "GAME_DAILY"` in config.py

NOTE:
- GAME_CATEGORY and its channels (lobby and gameplay) will be created at bot startup.
- Bot only receives command under channels belong to GAME_CATEGORY
- In case GAME_CATEGORY is deleted, admin must restart bot.