### PR TITLE
Fix mentions not show names, adjust README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ https://dev.to/12944qwerty/hosting-a-discord-py-bot-with-repl-it-3l5a
 
 Explanation: Your bot will be alive because the monitoring services request(ping) every 5-10 minutes and keeps our website running up.
 
+Alternatives: Some deployment services may block request from UptimeRobot, please consider others website:
+https://cron-job.org/en/
+https://uptime.com/
+https://uptime-monitor.io/
+
 # Contact
 It's open source and free to use Discord bot.
 
@@ -193,4 +198,4 @@ Discord chat group: https://discordapp.com/invite/jHwsRAN
 ## Library bug
 A library bug while adding member to `gameplay` channel if using `discord.py==2.2.2`
 
-Prefer to use `discord.py==1.7.3` 
+Prefer to use `discord.py==1.7.3`

--- a/README.md
+++ b/README.md
@@ -182,11 +182,6 @@ https://dev.to/12944qwerty/hosting-a-discord-py-bot-with-repl-it-3l5a
 
 Explanation: Your bot will be alive because the monitoring services request(ping) every 5-10 minutes and keeps our website running up.
 
-Alternatives: Some deployment services may block request from UptimeRobot, please consider others website:
-https://cron-job.org/en/
-https://uptime.com/
-https://uptime-monitor.io/
-
 # Contact
 It's open source and free to use Discord bot.
 
@@ -198,4 +193,4 @@ Discord chat group: https://discordapp.com/invite/jHwsRAN
 ## Library bug
 A library bug while adding member to `gameplay` channel if using `discord.py==2.2.2`
 
-Prefer to use `discord.py==1.7.3`
+Prefer to use `discord.py==1.7.3` 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -400,7 +400,7 @@ class Game:
             if isinstance(player, roles.Werewolf):
                 print("Wolf: ", player)
                 await self.interface.add_user_to_channel(_id, config.WEREWOLF_CHANNEL, is_read=True, is_send=True)
-                await self.interface.send_action_text_to_channel("werewolf_welcome_text", config.WEREWOLF_CHANNEL, user=f"<@{_id}>")
+                await self.interface.send_action_text_to_channel("werewolf_welcome_text", config.WEREWOLF_CHANNEL, user=f"<@!{_id}>")
                 werewolf_list.append(_id)
             # else:  # Enable this will not allow anyone to see config.WEREWOLF_CHANNEL including Admin player
             #     await self.interface.add_user_to_channel(_id, config.WEREWOLF_CHANNEL, is_read=False, is_send=False)
@@ -408,7 +408,7 @@ class Game:
         embed_data = text_template.generate_player_list_embed(self.get_alive_players(), alive_status=True)
         await asyncio.gather(*[role.on_start_game(embed_data) for role in self.get_alive_players()])
 
-        info = text_templates.generate_text("werewolf_list_text", werewolf_str=", ".join(f"<@{_id}>" for _id in werewolf_list))
+        info = text_templates.generate_text("werewolf_list_text", werewolf_str=", ".join(f"<@!{_id}>" for _id in werewolf_list))
         print("werewolf_list_text", info)
         await asyncio.gather(*[role.on_betrayer(info) for role in self.get_alive_players() if isinstance(role, roles.Betrayer)])
 
@@ -471,7 +471,7 @@ class Game:
                     [str(self.day)],
                     [game_winner],
                     text_template.generate_reveal_str_list(reveal_list),
-                    [" x ".join(f"<@{player_id}>" for player_id in self.cupid_dict.keys())] if self.cupid_dict else []
+                    [" x ".join(f"<@!{player_id}>" for player_id in self.cupid_dict.keys())] if self.cupid_dict else []
                 ],
                 start_time_str=self.start_time.strftime(text_templates.get_format_string("datetime"))
             )
@@ -545,7 +545,7 @@ class Game:
                 await self.players[lynched].get_killed()
                 await self.interface.send_action_text_to_channel(
                     "execution_player_text", config.GAMEPLAY_CHANNEL,
-                    voted_user=f"<@{lynched}>", highest_vote_number=votes
+                    voted_user=f"<@!{lynched}>", highest_vote_number=votes
                 )
 
                 cupid_couple = self.cupid_dict.get(lynched)
@@ -553,7 +553,7 @@ class Game:
                     await self.players[cupid_couple].get_killed(True)
                     await self.interface.send_action_text_to_channel(
                         "couple_died_on_day_text", config.GAMEPLAY_CHANNEL,
-                        died_player=f"<@{lynched}>", follow_player=f"<@{cupid_couple}>"
+                        died_player=f"<@!{lynched}>", follow_player=f"<@!{cupid_couple}>"
                     )
             else:
                 await self.interface.send_action_text_to_channel("execution_none_text", config.GAMEPLAY_CHANNEL)
@@ -609,7 +609,7 @@ class Game:
                     if self.cupid_dict.get(_id):
                         cupid_couple = self.cupid_dict[_id]
 
-            kills = ", ".join(f"<@{_id}>" for _id in final_kill_list)
+            kills = ", ".join(f"<@!{_id}>" for _id in final_kill_list)
             self.night_pending_kill_list = []  # Reset killed list for next day
 
         await self.interface.send_action_text_to_channel(
@@ -621,7 +621,7 @@ class Game:
             await self.players[cupid_couple].get_killed(True)
             await self.interface.send_action_text_to_channel(
                 "couple_died_on_night_text", config.GAMEPLAY_CHANNEL,
-                died_player=f"<@{self.cupid_dict[cupid_couple]}>", follow_player=f"<@{cupid_couple}>"
+                died_player=f"<@!{self.cupid_dict[cupid_couple]}>", follow_player=f"<@!{cupid_couple}>"
             )
 
         for _id in self.reborn_set:
@@ -797,7 +797,7 @@ class Game:
 
         # Vote for target user
         self.voter_dict[author_id] = target_id
-        return text_templates.generate_text("vote_text", author=f"<@{author_id}>", target=f"<@{target_id}>")
+        return text_templates.generate_text("vote_text", author=f"<@!{author_id}>", target=f"<@!{target_id}>")
 
     async def kill(self, author, target):
         if self.game_phase != GamePhase.NIGHT:
@@ -810,7 +810,7 @@ class Game:
         target_id = target.player_id
 
         self.wolf_kill_dict[author_id] = target_id
-        return text_templates.generate_text("werewolf_kill_text", werewolf=f"<@{author_id}>", target=f"<@{target_id}>")
+        return text_templates.generate_text("werewolf_kill_text", werewolf=f"<@!{author_id}>", target=f"<@!{target_id}>")
 
     async def guard(self, author, target):
         if self.game_phase != GamePhase.NIGHT:
@@ -833,7 +833,7 @@ class Game:
         author.on_use_mana()
         author.set_guard_target(target_id)
         target.get_protected()
-        return text_templates.generate_text("guard_after_voting_text", target=f"<@{target_id}>")
+        return text_templates.generate_text("guard_after_voting_text", target=f"<@!{target_id}>")
 
     async def seer(self, author, target):
         if self.game_phase != GamePhase.NIGHT:
@@ -854,7 +854,7 @@ class Game:
 
         return text_templates.generate_text(
             f"seer_after_voting_{'' if target.seer_seen_as_werewolf() else 'not_'}werewolf_text",
-            target=f"<@{target_id}>"
+            target=f"<@!{target_id}>"
         )
 
     async def reborn(self, author, target):
@@ -871,12 +871,12 @@ class Game:
             return text_templates.generate_text("out_of_power_text")
 
         if target.is_alive():
-            return text_templates.generate_text("invalid_player_alive_text", user=f"<@{target_id}>")
+            return text_templates.generate_text("invalid_player_alive_text", user=f"<@!{target_id}>")
 
         author.on_use_power()
         self.reborn_set.add(target_id)
 
-        return text_templates.generate_text("witch_after_reborn_text", target=f"<@{target_id}>")
+        return text_templates.generate_text("witch_after_reborn_text", target=f"<@!{target_id}>")
 
     async def curse(self, author, target):
         if not self.modes.get("witch_can_kill"):
@@ -898,7 +898,7 @@ class Game:
         # Kill someone
         self.night_pending_kill_list.append(target_id)
 
-        return text_templates.generate_text("witch_after_curse_text", target=f"<@{target_id}>")
+        return text_templates.generate_text("witch_after_curse_text", target=f"<@!{target_id}>")
 
     async def zombie(self, author):
         if self.game_phase != GamePhase.NIGHT:
@@ -935,18 +935,18 @@ class Game:
 
         await self.interface.send_action_text_to_channel(
             "couple_shipped_with_text",
-            self.players[target1_id].channel_name, target=f"<@{target2_id}> {target2.__class__.__name__}"
+            self.players[target1_id].channel_name, target=f"<@!{target2_id}> {target2.__class__.__name__}"
         )
         await self.interface.send_action_text_to_channel(
             "couple_shipped_with_text",
-            self.players[target2_id].channel_name, target=f"<@{target1_id}> {target1.__class__.__name__}"
+            self.players[target2_id].channel_name, target=f"<@!{target1_id}> {target1.__class__.__name__}"
         )
         await self.interface.create_channel(config.COUPLE_CHANNEL)
         await self.interface.add_user_to_channel(target1_id, config.COUPLE_CHANNEL, is_read=True, is_send=True)
         await self.interface.add_user_to_channel(target2_id, config.COUPLE_CHANNEL, is_read=True, is_send=True)
-        await self.interface.send_action_text_to_channel("couple_welcome_text", config.COUPLE_CHANNEL, user1=f"<@{target1_id}>", user2=f"<@{target2_id}>")
+        await self.interface.send_action_text_to_channel("couple_welcome_text", config.COUPLE_CHANNEL, user1=f"<@!{target1_id}>", user2=f"<@!{target2_id}>")
 
-        return text_templates.generate_text("cupid_after_ship_text", target1=f"<@{target1_id}>", target2=f"<@{target2_id}>")
+        return text_templates.generate_text("cupid_after_ship_text", target1=f"<@!{target1_id}>", target2=f"<@!{target2_id}>")
 
     async def register_auto(self, author, subcmd):
         def check(pred):

--- a/game/roles/character.py
+++ b/game/roles/character.py
@@ -37,7 +37,7 @@ class Character:
         await asyncio.gather(
             self.interface.add_user_to_channel(self.player_id, config.GAMEPLAY_CHANNEL, is_read=True, is_send=False),
             self.interface.add_user_to_channel(self.player_id, config.CEMETERY_CHANNEL, is_read=True, is_send=True),
-            self.interface.send_action_text_to_channel("after_death_text", config.CEMETERY_CHANNEL, user=f"<@{self.player_id}>"),
+            self.interface.send_action_text_to_channel("after_death_text", config.CEMETERY_CHANNEL, user=f"<@!{self.player_id}>"),
             self.interface.add_user_to_channel(self.player_id, config.COUPLE_CHANNEL, is_read=False, is_send=False)
         )
         return True
@@ -47,7 +47,7 @@ class Character:
         await asyncio.gather(
             self.interface.add_user_to_channel(self.player_id, config.GAMEPLAY_CHANNEL, is_read=True, is_send=True),
             self.interface.add_user_to_channel(self.player_id, config.CEMETERY_CHANNEL, is_read=False, is_send=False),
-            self.interface.send_action_text_to_channel("after_reborn_text", config.GAMEPLAY_CHANNEL, user=f"<@{self.player_id}>")
+            self.interface.send_action_text_to_channel("after_reborn_text", config.GAMEPLAY_CHANNEL, user=f"<@!{self.player_id}>")
         )
 
     def get_protected(self):

--- a/game/text_template.py
+++ b/game/text_template.py
@@ -17,7 +17,7 @@ def get_full_cmd_description(cmd):
 def generate_player_list_embed(player_list, alive_status=None, role_list=None):
     # Handle 3 types of list: Alive, Dead, Overview
     if player_list:
-        id_player_list = [f"{'💀' if alive_status is None and user.status == CharacterStatus.KILLED else row_id} -> <@{user.player_id}>" for row_id, user in enumerate(player_list, 1)]
+        id_player_list = [f"{'💀' if alive_status is None and user.status == CharacterStatus.KILLED else row_id} -> <@!{user.player_id}>" for row_id, user in enumerate(player_list, 1)]
         action_name = f"{'all' if alive_status is None else 'alive' if alive_status else 'dead'}_player_list_embed"
         embed_data = text_templates.generate_embed(action_name, [id_player_list] if role_list is None else [id_player_list, role_list])
         return embed_data

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -112,29 +112,29 @@
   "gameplay_join_text": {
     "params": ["player_id"],
     "template": {
-      "vi": ["Chào <@{player_id}>"],
-      "en": ["Hi <@{player_id}>"]
+      "vi": ["Chào <@!{player_id}>"],
+      "en": ["Hi <@!{player_id}>"]
     }
   },
   "gameplay_leave_text": {
     "params": ["player_id"],
     "template": {
-      "vi": ["Bye <@{player_id}>"],
-      "en": ["Bye <@{player_id}>"]
+      "vi": ["Bye <@!{player_id}>"],
+      "en": ["Bye <@!{player_id}>"]
     }
   },
   "gameplay_watch_text": {
     "params": ["player_id"],
     "template": {
-      "vi": ["Người xem <@{player_id}> đã theo dõi game."],
-      "en": ["Viewer <@{player_id}> has watched the game."]
+      "vi": ["Người xem <@!{player_id}> đã theo dõi game."],
+      "en": ["Viewer <@!{player_id}> has watched the game."]
     }
   },
   "gameplay_unwatch_text": {
     "params": ["player_id"],
     "template": {
-      "vi": ["Người xem <@{player_id}> đã bỏ theo dõi game."],
-      "en": ["Viewer <@{player_id}> has unwatched the game."]
+      "vi": ["Người xem <@!{player_id}> đã bỏ theo dõi game."],
+      "en": ["Viewer <@!{player_id}> has unwatched the game."]
     }
   },
   "reply_join_text": {
@@ -182,8 +182,8 @@
   "personal_channel_welcome_text": {
     "params": ["player_id", "player_role"],
     "template": {
-      "vi": ["Chào mừng <@{player_id}> tham gia game!\nVai của bạn là {player_role}"],
-      "en": ["Welcome <@{player_id}> to the game!\nYour role is {player_role}"]
+      "vi": ["Chào mừng <@!{player_id}> tham gia game!\nVai của bạn là {player_role}"],
+      "en": ["Welcome <@!{player_id}> to the game!\nYour role is {player_role}"]
     }
   },
   "too_quick_text": {
@@ -966,8 +966,8 @@
   "reveal_player_text": {
     "params": ["player_id", "role"],
     "template": {
-      "vi": ["<@{player_id}> là {role}"],
-      "en": ["<@{player_id}> is {role}"]
+      "vi": ["<@!{player_id}> là {role}"],
+      "en": ["<@!{player_id}> is {role}"]
     }
   },
   "time_range_whole_day_text": {


### PR DESCRIPTION
- Fix mentions sometimes don't show user names but long ID, simply add `!` before user ID
- Current functions should work properly but need more testing to see if the issue is actually fixed.
- Minor README.md adjustment.
- References:
https://stackoverflow.com/a/69759913
https://stackoverflow.com/questions/64214155/discord-py-mention-through-id-doesnt-show-name