### PR TITLE
Add result emoji for players on leaderboard, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ https://dev.to/12944qwerty/hosting-a-discord-py-bot-with-repl-it-3l5a
 
 Explanation: Your bot will be alive because the monitoring services request(ping) every 5-10 minutes and keeps our website running up.
 
+Alternatives: Some deployment services may block request from UptimeRobot, please consider others website:
+https://cron-job.org/en/
+https://uptime.com/
+https://uptime-monitor.io/
+
 # Contact
 It's open source and free to use Discord bot.
 
@@ -193,4 +198,4 @@ Discord chat group: https://discordapp.com/invite/jHwsRAN
 ## Library bug
 A library bug while adding member to `gameplay` channel if using `discord.py==2.2.2`
 
-Prefer to use `discord.py==1.7.3` 
+Prefer to use `discord.py==1.7.3`

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -460,7 +460,7 @@ class Game:
 
         reveal_list = [(_id, player.__class__.__name__) for _id, player in self.players.items()]
         await self.interface.send_text_to_channel(
-            "\n".join(text_template.generate_reveal_str_list(reveal_list)), config.GAMEPLAY_CHANNEL
+            "\n".join(text_template.generate_reveal_str_list(reveal_list, game_winner)), config.GAMEPLAY_CHANNEL
         )
 
         # write to leaderboard
@@ -469,9 +469,11 @@ class Game:
                 "game_result_embed",
                 [
                     [str(self.day)],
-                    [game_winner],
-                    text_template.generate_reveal_str_list(reveal_list),
-                    [" x ".join(f"<@{player_id}>" for player_id in self.cupid_dict.keys())] if self.cupid_dict else []
+                    # \u00A0\u00A0 is one space character for discord embed
+                    # Put \u200B\n at first of the next field to break line 
+                    [f"🎉\u00A0\u00A0\u00A0\u00A0{game_winner}\u00A0\u00A0\u00A0\u00A0🎉"],
+                    text_template.generate_reveal_str_list(reveal_list, game_winner),
+                    [" x ".join(f"<@!{player_id}>" for player_id in self.cupid_dict.keys())] if self.cupid_dict else []
                 ],
                 start_time_str=self.start_time.strftime(text_templates.get_format_string("datetime"))
             )

--- a/game/roles/__init__.py
+++ b/game/roles/__init__.py
@@ -42,6 +42,12 @@ def get_role_title(name):
 
         return name
 
+def get_role_party(name):
+    name = name.capitalize()
+    if name in role_info:
+        return role_info[name]["party"]
+
+    return None
 
 def get_role_description(name):
     name = name.capitalize()

--- a/game/roles/__init__.py
+++ b/game/roles/__init__.py
@@ -42,12 +42,14 @@ def get_role_title(name):
 
         return name
 
+
 def get_role_party(name):
     name = name.capitalize()
     if name in role_info:
         return role_info[name]["party"]
 
     return None
+
 
 def get_role_description(name):
     name = name.capitalize()

--- a/game/text_template.py
+++ b/game/text_template.py
@@ -196,10 +196,12 @@ def generate_modes(modes_dict):
         "===========================================================================\n"
 
 
-def generate_reveal_str_list(reveal_list):
+def generate_reveal_str_list(reveal_list, game_winner):
+    winner_list = [(player_id, role, '🥳' if roles.get_role_party(role) == game_winner else '😭') for player_id, role in reveal_list]
+
     return [
-        "- " + text_templates.generate_text("reveal_player_text", player_id=player_id, role=role)
-        for player_id, role in reveal_list
+        "- " + text_templates.generate_text("reveal_player_text", player_id=player_id, role=role, result_emoji=result_emoji)
+        for player_id, role, result_emoji in winner_list
     ]
 
 

--- a/json/role_info.json
+++ b/json/role_info.json
@@ -1,6 +1,7 @@
 {
   "Villager": {
     "name_vi": "Dân làng",
+    "party": "Villager",
     "description": {
       "vi": "Không có chức năng đặc biệt.",
       "en": "A simple villager."
@@ -10,6 +11,7 @@
   },
   "Werewolf": {
     "name_vi": "Sói",
+    "party": "Werewolf",
     "description": {
       "vi": "Chọn 1 người để giết mỗi đêm.",
       "en": "Chooses a player to kill at night."
@@ -19,6 +21,7 @@
   },
   "Superwolf": {
     "name_vi": "Sói già",
+    "party": "Werewolf",
     "description": {
       "vi": "Chọn 1 người để giết mỗi đêm. Sói già có khả năng che giấu Tiên tri và không bị soi ra là sói.",
       "en": "Chooses a player to kill at night. Can't be seen as a Werewolf."
@@ -28,6 +31,7 @@
   },
   "Guard": {
     "name_vi": "Bảo vệ",
+    "party": "Villager",
     "description": {
       "vi": "Bảo vệ được chọn 1 người khác nhau mỗi đêm và người được chọn sẽ bất tử đêm đó.",
       "en": "Guards a player: Protect the player from being killed."
@@ -37,6 +41,7 @@
   },
   "Lycan": {
     "name_vi": "Người hóa sói",
+    "party": "Villager",
     "description": {
       "vi": "Người hóa sói thuộc Phe dân làng, nhưng nếu được chỉ định bởi Tiên tri, thì sẽ bị thông báo là Sói.",
       "en": "A villager but is seen as a Werewolf."
@@ -46,6 +51,7 @@
   },
   "Seer": {
     "name_vi": "Tiên tri",
+    "party": "Villager",
     "description": {
       "vi": "Soi một người chơi có phải là sói hay không. Có thể giết chết Cáo nếu soi trúng Cáo.",
       "en": "Sees who is the Werewolf. Can kill Fox if Seer sees Fox."
@@ -55,6 +61,7 @@
   },
   "Betrayer": {
     "name_vi": "Kẻ phản bội",
+    "party": "Werewolf",
     "description": {
       "vi": "Là người nhưng bị mua chuộc theo phe sói. Kẻ phản bội biết ai là sói nhưng phe sói không biết ai là Kẻ phản bội.",
       "en": "A human but betrays Villagers. Betrayer knows werewolf players."
@@ -64,6 +71,7 @@
   },
   "Fox": {
     "name_vi": "Cáo",
+    "party": "Fox",
     "description": {
       "vi": "Thuộc phe thứ ba, Cáo sẽ chiến thắng nếu tất cả sói bị giết. Sẽ chết nếu bị Tiên tri soi trúng. Tuy nhiên, Cáo không chết nếu được Bảo vệ trong đêm bị soi.",
       "en": "A Fox belongs to third party. Fox wins if all werewolves are killed. Fox is dead if being revealed by Seer. Fox will not be dead if being protected by Guard."
@@ -73,6 +81,7 @@
   },
   "Witch": {
     "name_vi": "Phù thủy",
+    "party": "Villager",
     "description": {
       "vi": "Vào ban đêm, Phù thủy có 1 bình phép có thể phục sinh một người chơi đã chết, đôi khi cũng có thể nguyền rủa một người còn sống. Mỗi chức năng này chỉ được sử dụng một lần duy nhất trong game.",
       "en": "Can reborn a dead player, and also can curse an alive player once per game."
@@ -82,6 +91,7 @@
   },
   "Zombie": {
     "name_vi": "Xác sống",
+    "party": "Villager",
     "description": {
       "vi": "Có thể tự hồi sinh một lần duy nhất trong game.",
       "en": "Can reborn once."
@@ -91,6 +101,7 @@
   },
   "Cupid": {
     "name_vi": "Thần tình yêu",
+    "party": "Cupid",
     "description": {
       "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót.",
       "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players."

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -964,10 +964,10 @@
     }
   },
   "reveal_player_text": {
-    "params": ["player_id", "role"],
+    "params": ["player_id", "role", "result_emoji"],
     "template": {
-      "vi": ["<@{player_id}> là {role}"],
-      "en": ["<@{player_id}> is {role}"]
+      "vi": ["<@{player_id}> là {role} {result_emoji}"],
+      "en": ["<@{player_id}> is {role} {result_emoji}"]
     }
   },
   "time_range_whole_day_text": {
@@ -1111,12 +1111,12 @@
       "vi": {
         "title": "Kết quả trò chơi",
         "description": "Trò chơi đã bắt đầu lúc {start_time_str}.",
-        "content_headers": ["Số ngày đã trải qua", "🏆 Phe chiến thắng", "📝 Danh sách role", "💘 Cặp đôi vàng"]
+        "content_headers": ["Số ngày đã trải qua", "\u200B\n🏆 Phe chiến thắng", "\u200B\n📝 Danh sách người chơi", "💘 Cặp đôi vàng"]
       },
       "en": {
         "title": "Game result",
         "description": "Game has been started at {start_time_str}.",
-        "content_headers": ["Number of days", "🏆 Winner", "📝 Role list", "💘 Couple"]
+        "content_headers": ["Number of days", "\u200B\n🏆 The Winner", "\u200B\n📝 Player list", "💘 Couple"]
       }
     }
   }


### PR DESCRIPTION
- Add result emoji for players on leaderboard. Winners celebrating, losers crying.
ref #125 
- Update README.md

![image](https://github.com/dnh-bot/dnh-werewolf-bot/assets/56860673/6b3b75bf-f82f-4e35-a8c5-0e0d3614197b)
