### PR TITLE
Add selfcheck command, fix join issue

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -69,10 +69,12 @@ async def parse_command(client, game, message):
         elif cmd in ("vote", "kill", "guard", "seer", "reborn", "curse", "zombie", "ship", "auto"):
             if not game.is_started():
                 # prevent user uses command before game starts
-                return await message.reply(text_templates.generate_text("game_not_started_text"))
+                await message.reply(text_templates.generate_text("game_not_started_text"))
+                return
 
             if not game.is_in_play_time():
-                return await message.reply(text_templates.generate_text("game_not_playing_text"))
+                await message.reply(text_templates.generate_text("game_not_playing_text"))
+                return
 
             is_valid_channel = \
                 (cmd == "vote" and message.channel.name == config.GAMEPLAY_CHANNEL) or\
@@ -123,12 +125,14 @@ async def parse_command(client, game, message):
                 )
         elif cmd == "selfcheck":
             if not game.is_started():
-                return await message.reply(text_templates.generate_text("game_not_started_text"))
+                await message.reply(text_templates.generate_text("game_not_started_text"))
+                return
             if message.channel.name not in (config.GAMEPLAY_CHANNEL, config.LOBBY_CHANNEL): # Only use in common channels, no spamming
-                return await admin.send_text_to_channel(
+                await admin.send_text_to_channel(
                     message.guild, text_templates.generate_text(
                         "invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL} #{config.GAMEPLAY_CHANNEL}"), message.channel.name
                 )
+                return
             msg = await game.self_check_channel()
             await message.reply(msg)
 
@@ -176,7 +180,8 @@ async def parse_command(client, game, message):
                 timer_phase = list(map(int, parameters))
                 # Check if any timer phase is too short (<= 5 seconds):
                 if not timer_phase or any(map(lambda x: x <= 5, timer_phase)):
-                    return await message.reply("Config must greater than 5s")
+                    await message.reply("Config must greater than 5s")
+                    return
                 await message.reply(
                     text_templates.generate_text(
                         "timer_settings_text",

--- a/commands/command.py
+++ b/commands/command.py
@@ -123,6 +123,18 @@ async def parse_command(client, game, message):
                     message.guild, text_templates.generate_text(
                         "invalid_channel_text", channel=real_channel), message.channel.name
                 )
+        elif cmd == "selfcheck":
+            if not game.is_started():
+                await message.reply(text_templates.generate_text("game_not_started_text"))
+                return None
+            if message.channel.name not in (config.GAMEPLAY_CHANNEL, config.LOBBY_CHANNEL): # Only use in common channels, no spamming
+                await admin.send_text_to_channel(
+                    message.guild, text_templates.generate_text(
+                        "invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL} #{config.GAMEPLAY_CHANNEL}"), message.channel.name
+                )
+                return None
+            msg = await game.self_check_channel()
+            await message.reply(msg)
 
         elif cmd == "status":
             if game.is_ended():

--- a/commands/command.py
+++ b/commands/command.py
@@ -125,14 +125,12 @@ async def parse_command(client, game, message):
                 )
         elif cmd == "selfcheck":
             if not game.is_started():
-                await message.reply(text_templates.generate_text("game_not_started_text"))
-                return None
+                return await message.reply(text_templates.generate_text("game_not_started_text"))
             if message.channel.name not in (config.GAMEPLAY_CHANNEL, config.LOBBY_CHANNEL): # Only use in common channels, no spamming
-                await admin.send_text_to_channel(
+                return await admin.send_text_to_channel(
                     message.guild, text_templates.generate_text(
                         "invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL} #{config.GAMEPLAY_CHANNEL}"), message.channel.name
                 )
-                return None
             msg = await game.self_check_channel()
             await message.reply(msg)
 

--- a/commands/command.py
+++ b/commands/command.py
@@ -128,10 +128,7 @@ async def parse_command(client, game, message):
                 await message.reply(text_templates.generate_text("game_not_started_text"))
                 return
             if message.channel.name not in (config.GAMEPLAY_CHANNEL, config.LOBBY_CHANNEL): # Only use in common channels, no spamming
-                await admin.send_text_to_channel(
-                    message.guild, text_templates.generate_text(
-                        "invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL} #{config.GAMEPLAY_CHANNEL}"), message.channel.name
-                )
+                await message.reply(text_templates.generate_text("invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL} #{config.GAMEPLAY_CHANNEL}"))
                 return
             msg = await game.self_check_channel()
             await message.reply(msg)

--- a/commands/command.py
+++ b/commands/command.py
@@ -69,12 +69,10 @@ async def parse_command(client, game, message):
         elif cmd in ("vote", "kill", "guard", "seer", "reborn", "curse", "zombie", "ship", "auto"):
             if not game.is_started():
                 # prevent user uses command before game starts
-                await message.reply(text_templates.generate_text("game_not_started_text"))
-                return None
+                return await message.reply(text_templates.generate_text("game_not_started_text"))
 
             if not game.is_in_play_time():
-                await message.reply(text_templates.generate_text("game_not_playing_text"))
-                return None
+                return await message.reply(text_templates.generate_text("game_not_playing_text"))
 
             is_valid_channel = \
                 (cmd == "vote" and message.channel.name == config.GAMEPLAY_CHANNEL) or\
@@ -178,8 +176,7 @@ async def parse_command(client, game, message):
                 timer_phase = list(map(int, parameters))
                 # Check if any timer phase is too short (<= 5 seconds):
                 if not timer_phase or any(map(lambda x: x <= 5, timer_phase)):
-                    await message.reply("Config must greater than 5s")
-                    return None
+                    return await message.reply("Config must greater than 5s")
                 await message.reply(
                     text_templates.generate_text(
                         "timer_settings_text",

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -37,7 +37,7 @@ class Game:
         self.play_time_start = datetime.time(0, 0, 0)  # in UTC
         self.play_time_end = datetime.time(0, 0, 0)  # in UTC
         self.play_zone = "UTC+7"
-        self.asyncLock = asyncio.Lock()
+        self.async_lock = asyncio.Lock()
         self.reset_game_state()  # Init other game variables every end game.
 
     def reset_game_state(self):
@@ -245,13 +245,13 @@ class Game:
             await asyncio.gather(
             *[player.create_personal_channel(self_check=True) for player in self.players.values()]
         )
-            
+
             return text_templates.generate_text('self_check_text')
         except Exception as e:
             print(e)
 
     async def add_player(self, id_, player_name):
-        async with self.asyncLock:
+        async with self.async_lock:
             if id_ in self.players:
                 return -1
 

--- a/game/roles/character.py
+++ b/game/roles/character.py
@@ -61,13 +61,14 @@ class Character:
     def get_mana(self):
         return self.mana
 
-    async def create_personal_channel(self):
+    async def create_personal_channel(self, self_check = False):
         await self.interface.create_channel(self.channel_name)
         await self.interface.add_user_to_channel(self.player_id, self.channel_name, is_read=True, is_send=True)
-        await self.interface.send_action_text_to_channel(
-            "personal_channel_welcome_text", self.channel_name,
-            player_id=self.player_id, player_role=self.__class__.__name__
-        )
+        if not self_check:
+            await self.interface.send_action_text_to_channel(
+                "personal_channel_welcome_text", self.channel_name,
+                player_id=self.player_id, player_role=self.__class__.__name__
+            )
         print("Created channel", self.channel_name)
 
     async def send_to_personal_channel(self, text):

--- a/json/command_info.json
+++ b/json/command_info.json
@@ -96,6 +96,14 @@
     "exclusive_roles": [],
     "required_params": []
   },
+  "selfcheck": {
+    "description": {
+      "vi": "Kiểm tra lại tất cả channel người chơi.",
+      "en": "Re-check all player channels."
+    },
+    "exclusive_roles": [],
+    "required_params": []
+  },
   "next": {
     "description": {
       "vi": "Nhảy đến phase sau (cần đủ số lượng vote).",

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -216,6 +216,13 @@
       "en": ["All players are ready. The system will assign roles and the game will begin soon!"]
     }
   },
+  "self_check_text": {
+    "params": [],
+    "template": {
+      "vi": ["Tất cả channel người chơi đã được kiểm tra!"],
+      "en": ["Player channels have been checked!"]
+    }
+  },
   "end_text": {
     "params": [],
     "template": {


### PR DESCRIPTION
- Players usually do not see their `personal channel`, now add `selfcheck` command to re-check channel permissions.
Note: Please consider if we should also check others channel like `gameplay`, `cemetery`, `werewolf`, `cupid`. Checking all channels seem redundant.

- Fix issue when  multiple players join at the same time, please see images below.
Ref: https://tutorialedge.net/python/concurrency/asyncio-synchronization-primitives-tutorial/

![image](https://github.com/dnh-bot/dnh-werewolf-bot/assets/56860673/9c804cce-8b6c-4b2b-b3ef-7db17d3052a4)

FIXED 
![image](https://github.com/dnh-bot/dnh-werewolf-bot/assets/56860673/abf14c53-0b87-4126-95b5-01ffa98cdaf6)
