### PR TITLE
Fix cupid win emoji, enhance description

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ https://dev.to/12944qwerty/hosting-a-discord-py-bot-with-repl-it-3l5a
 Explanation: Your bot will be alive because the monitoring services request(ping) every 5-10 minutes and keeps our website running up.
 
 Alternatives: Some deployment services may block request from UptimeRobot, please consider others website:
+https://www.fastcron.com/
 https://cron-job.org/en/
 https://uptime.com/
 https://uptime-monitor.io/

--- a/STORY_VN.md
+++ b/STORY_VN.md
@@ -20,7 +20,7 @@ Vậy bên nào sẽ chiến thắng, Thường dân, Werewolf, hay là phe Ph�
 ### I. Phe dân: Chiến thắng nếu sống sót và tiêu diệt được hết Sói và Cáo. Không thể nhận biết được người cùng phe.
 
 - [Villager] Dân làng: Không có chức năng đặc biệt.
-- [Villager Chief] Trưởng làng: Được vote tính 2 phiếu.
+- [Villager Chief] Trưởng làng: Được vote tính bí mật 2 phiếu.
 - [Seer] Tiên tri: Soi một người chơi có phải là sói hay không. Có thể giết chết Cáo nếu soi trúng Cáo.
 - [Guard] Bảo vệ: Bảo vệ được chọn 1 người khác nhau mỗi đêm trừ bản thân và người được chọn sẽ bất tử đêm đó.
 - [Lycan] Người hóa sói: Người hóa sói thuộc Phe dân làng, nhưng nếu được chỉ định bởi Tiên tri, thì sẽ bị thông báo là Sói.
@@ -31,10 +31,10 @@ Vậy bên nào sẽ chiến thắng, Thường dân, Werewolf, hay là phe Ph�
 - [Superwolf] Sói già: Chọn 1 người để giết mỗi đêm. Sói già có khả năng che giấu Tiên tri và không bị soi ra là sói.
 - [Betrayer] Kẻ phản bội: Là **người** nhưng bị mua chuộc theo phe sói. Betrayer biết ai là sói nhưng phe sói không biết ai là Betrayer.
 
-### III. Phe thứ 3: Chiến thắng khi sống sót cuối cùng. Không thể nhận biết được người cùng phe.
+### III. Phe thứ 3: Chiến thắng với những điều kiện đặc biệt
 
 - [Fox] Cáo: Thuộc phe thứ ba, cáo sẽ chiến thắng nếu tất cả sói bị giết. Sẽ chết nếu bị Tiên tri soi trúng. Tuy nhiên, Cáo không chết nếu được Bảo vệ trong đêm bị soi.
-- [Cupid] Thần tình yêu: Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót.
+- [Cupid] Thần tình yêu: Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ sẽ chiến thắng khi là hai người cuối cùng sống sót (hoặc khi phe của họ thắng). Thần tình yêu có thể chiến thắng cùng cặp đôi hoặc khi dân làng thắng.
 
 
 

--- a/bot.py
+++ b/bot.py
@@ -34,7 +34,7 @@ async def process_message(discord_client, message):
         game = game_list.get_game(message.guild.id)
         if game is None:
             # Init game_list
-            init_setup(True)
+            await init_setup(True)
             game = game_list.get_game(message.guild.id)
 
         await command.parse_command(discord_client, game, message)

--- a/game/text_template.py
+++ b/game/text_template.py
@@ -230,11 +230,10 @@ def generate_reveal_str_list(reveal_list, game_winner, cupid_dict):
 
 def generate_winner_list(reveal_list, game_winner, cupid_dict):
     winner_list = []
-    couple_win = all(roles.get_role_party(role) == game_winner for player_id, role in reveal_list if player_id in cupid_dict)
     for player_id, role in reveal_list:
         party_victory = roles.get_role_party(role) == game_winner
-        # Cupid always follow the couple win condition
-        cupid_victory = (game_winner == 'Cupid' or couple_win) and (role == 'Cupid' or player_id in cupid_dict)
+        # Cupid is in Villager team. Win with either couple or Villager
+        cupid_victory = game_winner == 'Cupid' and (player_id in cupid_dict or role == 'Cupid')
 
         if party_victory or cupid_victory:
             emoji = '🥳'

--- a/game/text_template.py
+++ b/game/text_template.py
@@ -230,9 +230,11 @@ def generate_reveal_str_list(reveal_list, game_winner, cupid_dict):
 
 def generate_winner_list(reveal_list, game_winner, cupid_dict):
     winner_list = []
+    couple_win = all(roles.get_role_party(role) == game_winner for player_id, role in reveal_list if player_id in cupid_dict)
     for player_id, role in reveal_list:
         party_victory = roles.get_role_party(role) == game_winner
-        cupid_victory = game_winner == 'Cupid' and player_id in cupid_dict
+        # Cupid always follow the couple win condition
+        cupid_victory = (game_winner == 'Cupid' or couple_win) and (role == 'Cupid' or player_id in cupid_dict)
 
         if party_victory or cupid_victory:
             emoji = '🥳'

--- a/json/role_info.json
+++ b/json/role_info.json
@@ -101,7 +101,7 @@
   },
   "Cupid": {
     "name_vi": "Thần tình yêu",
-    "party": "Cupid",
+    "party": "Villager",
     "description": {
       "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót. Thần tình yêu có trách nhiệm đảm bảo cho cặp đôi giành chiến thắng",
       "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players. Cupid is responsible for ensuring the couple wins"

--- a/json/role_info.json
+++ b/json/role_info.json
@@ -103,8 +103,8 @@
     "name_vi": "Thần tình yêu",
     "party": "Cupid",
     "description": {
-      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót.",
-      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players."
+      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót. Thần tình yêu có trách nhiệm đảm bảo cho cặp đôi giành chiến thắng",
+      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players. Cupid is responsible for ensuring the couple wins"
     },
     "daytime_command": "vote",
     "nighttime_commands": ["ship"]

--- a/json/role_info.json
+++ b/json/role_info.json
@@ -103,8 +103,8 @@
     "name_vi": "Thần tình yêu",
     "party": "Villager",
     "description": {
-      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót. Thần tình yêu chiến thắng cùng cặp đôi hoặc khi dân làng thắng",
-      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players. Cupid wins together with the couple or the Villagers"
+      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ sẽ chiến thắng khi là hai người cuối cùng sống sót (hoặc khi phe của họ thắng). Thần tình yêu có thể chiến thắng cùng cặp đôi hoặc khi dân làng thắng.",
+      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they will win if they are the last stand players (or when their own team win). Cupid may win together with the couple or the Villagers."
     },
     "daytime_command": "vote",
     "nighttime_commands": ["ship"]
@@ -113,8 +113,8 @@
     "name_vi": "Trưởng làng",
     "party": "Villager",
     "description": {
-      "vi": "Vào ban ngày, phiếu bầu của Trưởng làng được tính là 2",
-      "en": "On dayphase, the Chief's vote is counted as 2"
+      "vi": "Vào ban ngày, phiếu bầu của Trưởng làng được bí mật tính là 2.",
+      "en": "On dayphase, the Chief's vote is secretly counted as 2."
     },
     "daytime_command": "vote",
     "nighttime_commands": []

--- a/json/role_info.json
+++ b/json/role_info.json
@@ -103,8 +103,8 @@
     "name_vi": "Thần tình yêu",
     "party": "Villager",
     "description": {
-      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót. Thần tình yêu có trách nhiệm đảm bảo cho cặp đôi giành chiến thắng",
-      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players. Cupid is responsible for ensuring the couple wins"
+      "vi": "Đầu mỗi ván chơi, Cupid sẽ được gọi dậy và chọn ra hai người yêu nhau. Cặp đó sẽ chết nếu 1 trong 2 bị chết. Nếu hai người thuộc hai phe khác nhau (Sói vs Dân) thì họ thành phe thứ 3 với nhiệm vụ là hai người cuối cùng sống sót. Thần tình yêu chiến thắng cùng cặp đôi hoặc khi dân làng thắng",
+      "en": "On the first day, Cupid can choose 2 players and make them to be a couple. If one of them is dead, the other will be also dead. If the couple belongs to different parties (Werewolf and Villager), then they become the third party. Their mission is to be the last stand players. Cupid wins together with the couple or the Villagers"
     },
     "daytime_command": "vote",
     "nighttime_commands": ["ship"]


### PR DESCRIPTION
~- Fix cupid win emoji. Cupid always win together, as long as the couple wins~
- Enhance descriptions, story VN
- Add missing await

- Fix Cupid winning emoji

`Cupid wins if the couple are the last players alive or the village wins.`
`You are always supposed to help your couple unless : Your couple has 2 werewolves. (In this situation, you can't win because werewolf win condition will come before couple).`
`When couple dies, don't let anyone claim cupid.` 
--> Cupid can still support and win with the Villager, this also reasonable when Cupid may not ship any couple :D

Ref: https://www.reddit.com/r/werewolfonline/comments/14fb2l9/a_full_guide_on_cupid/


`Lovers are a special separate team made by the Cupid
. Their goal is to go for a Lovers Win or their team win.`
--> Couple can win either with their lover or their original team. They may decide the strategy to follow.

Ref: https://agrou.fandom.com/wiki/Lovers