### PR TITLE
Add rematch command

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,7 @@ disable=
     W0401, # wildcard-import
     W0614, # unused-wildcard-import
     W0718, # broad-exception-caught
+    R0911, # too-many-return-statements
     R0914, # too-many-locals
     R0915, # too-many-statements
     W0511, # fixme

--- a/commands/command.py
+++ b/commands/command.py
@@ -90,7 +90,7 @@ async def parse_command(client, game, message):
         elif cmd == "stopgame":
             await player.do_stop(game, message, force=False)
         elif cmd == "rematch":
-            if message.channel.name not in (config.LOBBY_CHANNEL):  # Any player can request rematch, so only allow in Lobby
+            if message.channel.name != config.LOBBY_CHANNEL:  # Any player can request rematch, so only allow in Lobby
                 await message.reply(text_templates.generate_text("invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL}"))
                 return
             await player.do_rematch(game, message)

--- a/commands/command.py
+++ b/commands/command.py
@@ -168,7 +168,7 @@ async def parse_command(client, game, message):
                     message.guild, text_templates.generate_text("end_text"), message.channel.name
                 )
             else:
-                status_description, remaining_time, vote_table, table_title, author_status = game.get_game_status(
+                status_description, passed_days, remaining_time, vote_table, table_title, author_status = game.get_game_status(
                     message.channel.name, message.author.id
                 )
                 print(status_description, remaining_time, vote_table,
@@ -176,6 +176,7 @@ async def parse_command(client, game, message):
                 embed_data = text_templates.generate_embed(
                     "game_status_with_table_embed",
                     [
+                        [passed_days],
                         [text_template.generate_timer_remaining_text(remaining_time)],
                         text_template.generate_vote_field(vote_table),
                         [author_status]

--- a/commands/command.py
+++ b/commands/command.py
@@ -89,6 +89,11 @@ async def parse_command(client, game, message):
             await player.do_next(game, message, force=False)
         elif cmd == "stopgame":
             await player.do_stop(game, message, force=False)
+        elif cmd == "rematch":
+            if message.channel.name not in (config.LOBBY_CHANNEL):  # Any player can request rematch, so only allow in Lobby
+                await message.reply(text_templates.generate_text("invalid_channel_text", channel=f"#{config.LOBBY_CHANNEL}"))
+                return
+            await player.do_rematch(game, message)
 
         elif cmd in ("vote", "kill", "guard", "seer", "hunter", "reborn", "curse", "zombie", "ship", "auto"):
             if not game.is_started():

--- a/commands/player.py
+++ b/commands/player.py
@@ -163,6 +163,7 @@ async def do_rematch(game, message):
         if message.author.id not in game.players:
             await message.reply(text_templates.generate_text("not_in_game_text"))
         else:
+            await message.reply(text_templates.generate_text("rematch_text"))
             await game.rematch(message.author.id)
     else:
         await message.reply(text_templates.generate_text("game_not_started_text"))

--- a/commands/player.py
+++ b/commands/player.py
@@ -156,6 +156,18 @@ async def do_stop(game, message, force=False):
         await message.reply(text_templates.generate_text("game_not_started_text"))
 
 
+# Player can call to rematch when they want without voting
+async def do_rematch(game, message):
+    """Rematch game"""
+    if game.is_started():
+        if message.author.id not in game.players:
+            await message.reply(text_templates.generate_text("not_in_game_text"))
+        else:
+            await game.rematch(message.author.id)
+    else:
+        await message.reply(text_templates.generate_text("game_not_started_text"))
+
+
 async def test_player_command(_):
     # TODO:
     pass

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -256,6 +256,10 @@ class Game:
 
         self.reset_game_state(True)
         await self.interface.create_channel(config.GAMEPLAY_CHANNEL)
+        # Add current players to Gameplay
+        await asyncio.gather(
+            *[self.interface.add_user_to_channel(_id, config.GAMEPLAY_CHANNEL, is_read=True, is_send=True) for _id in self.players]
+        )
         await asyncio.sleep(0)
 
     async def delete_channel(self):

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -374,13 +374,14 @@ class Game:
         author status.
         """
         status_description = ""
+        passed_days = str(self.day) if self.day > 0 else ""
         remaining_time = None
         vote_table = None
         table_title = ""
         author_status = ""
 
         if self.is_ended() or not isinstance(self.game_phase, const.GamePhase):
-            return status_description, remaining_time, vote_table, table_title, author_status
+            return status_description, passed_days, remaining_time, vote_table, table_title, author_status
 
         if self.game_phase == const.GamePhase.NEW_GAME:
             status_description = text_templates.get_label_in_language("new_game_phase_status")
@@ -433,7 +434,7 @@ class Game:
                 # TODO: future features in #cemetery channel
                 author_status = text_templates.get_label_in_language("author_dead_status")
 
-        return status_description, remaining_time, vote_table, table_title, author_status
+        return status_description, passed_days, remaining_time, vote_table, table_title, author_status
 
     def get_vote_status(self, voter_dict=None):
         # From {"u1":"u2", "u2":"u1", "u3":"u1"}

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -253,7 +253,7 @@ class Game:
             total_players=len(self.players)
         )
         await self.interface.send_embed_to_channel(rematch_data, config.LOBBY_CHANNEL)
- 
+
         self.reset_game_state(True)
         await self.interface.create_channel(config.GAMEPLAY_CHANNEL)
         await asyncio.sleep(0)

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -40,11 +40,11 @@ class Game:
         self.async_lock = asyncio.Lock()
         self.reset_game_state()  # Init other game variables every end game.
 
-    def reset_game_state(self, rematch=False):
+    def reset_game_state(self, is_rematching=False):
         print("reset_game_state")
         self.is_stopped = True
         self.start_time = None
-        if rematch:
+        if is_rematching:
             self.players = {player_id: None for player_id in self.players}
         else:
             self.players = {}  # id: Player

--- a/json/command_info.json
+++ b/json/command_info.json
@@ -120,6 +120,14 @@
     "exclusive_roles": [],
     "required_params": []
   },
+  "rematch": {
+    "description": {
+      "vi": "Yêu cầu chơi lại cùng những người chơi hiện tại",
+      "en": "Request a rematch with current players"
+    },
+    "exclusive_roles": [],
+    "required_params": []
+  },
   "status": {
     "description": {
       "vi": "Xem trạng thái trò chơi trong buổi hiện tại.",

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -1155,12 +1155,12 @@
       "vi": {
         "title": "Trạng thái trò chơi",
         "description": "{status_description}",
-        "content_headers": ["⏰ Thời gian còn lại của {phase_str}", "{table_title}", "Trạng thái của bạn"]
+        "content_headers": ["Số ngày đã trải qua", "⏰ Thời gian còn lại của {phase_str}", "{table_title}", "Trạng thái của bạn"]
       },
       "en": {
         "title": "Game status",
         "description": "{status_description}",
-        "content_headers": ["⏰ Remaining time of {phase_str}", "{table_title}", "Your status"]
+        "content_headers": ["Number of days", "⏰ Remaining time of {phase_str}", "{table_title}", "Your status"]
       }
     }
   },

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -722,6 +722,13 @@
       "en": ["Game stopped!"]
     }
   },
+  "rematch_text": {
+    "params": [],
+    "template": {
+      "vi": ["🔄 Đang tái tạo trò chơi..."],
+      "en": ["🔄 Recreating the game..."]
+    }
+  },
   "game_not_playing_text": {
     "params": [],
     "template": {

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -1173,6 +1173,22 @@
       }
     }
   },
+  "rematch_embed": {
+    "params": ["rematch_player_id", "total_players"],
+    "color": "0xe67e22",
+    "template": {
+      "vi": {
+        "title": "Trận tái đấu",
+        "description": "<@{rematch_player_id}> cay cú đã yêu cầu một trận tái đấu 😡😤",
+        "content_headers": ["\u200B\nDanh sách {total_players} người chơi hiện tại"]
+      },
+      "en": {
+        "title": "Rematch",
+        "description": "<@{rematch_player_id}> was so bitter that he asked for a rematch 😡😤",
+        "content_headers": ["\u200B\nList of {total_players} current players"]
+      }
+    }
+  },
   "new_moon_no_event_text": {
     "params": [],
     "template": {


### PR DESCRIPTION
Resolved #153 

- Any player can use this command, but only allowed in `Lobby` channel, a rematch announcement will be sent
- Players still need to use `start` command as usual to start a new game
- Added number of passed days to status embed

![image](https://github.com/dnh-bot/dnh-werewolf-bot/assets/56860673/46c770df-c2ab-48d1-9c6b-0711f46b0b0e)

![image](https://github.com/dnh-bot/dnh-werewolf-bot/assets/56860673/c725a1ea-bf9a-49de-a3ac-63d75f66276d)