### PR TITLE
Prevent dead players from adding reactions to messages in GAMEPLAY channel

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -122,7 +122,7 @@ async def add_user_to_channel(guild, user, channel_name, is_read=True, is_send=T
         await asyncio.sleep(1)  # Wait 1s here to wait for channel is ready
         channel = discord.utils.get(guild.channels, name=channel_name, category=category)
     try:
-        await channel.set_permissions(user, read_messages=is_read, send_messages=is_send)
+        await channel.set_permissions(user, read_messages=is_read, send_messages=is_send, add_reactions=is_send)
         print(f"Successfully added {user} to {channel_name} read={is_read} send={is_send}")
         return True
     except Exception as e:
@@ -137,7 +137,7 @@ async def remove_user_from_channel(guild, user, channel_name):
     category = discord.utils.get(guild.categories, name=config.GAME_CATEGORY)
     channel = discord.utils.get(guild.channels, name=channel_name, category=category)
     try:
-        await channel.set_permissions(user, read_messages=False, send_messages=False)
+        await channel.set_permissions(user, read_messages=False, send_messages=False, add_reactions=False)
         print("Successfully removed ", user, " from ", channel_name)
         return True
     except Exception as e:

--- a/commands/admin.py
+++ b/commands/admin.py
@@ -122,7 +122,7 @@ async def add_user_to_channel(guild, user, channel_name, is_read=True, is_send=T
         await asyncio.sleep(1)  # Wait 1s here to wait for channel is ready
         channel = discord.utils.get(guild.channels, name=channel_name, category=category)
     try:
-        await channel.set_permissions(user, read_messages=is_read, send_messages=is_send, add_reactions=is_send)
+        await channel.set_permissions(user, read_messages=is_read, send_messages=is_send, add_reactions=is_send, create_public_threads=is_send, create_private_threads=False)
         print(f"Successfully added {user} to {channel_name} read={is_read} send={is_send}")
         return True
     except Exception as e:
@@ -137,7 +137,7 @@ async def remove_user_from_channel(guild, user, channel_name):
     category = discord.utils.get(guild.categories, name=config.GAME_CATEGORY)
     channel = discord.utils.get(guild.channels, name=channel_name, category=category)
     try:
-        await channel.set_permissions(user, read_messages=False, send_messages=False, add_reactions=False)
+        await channel.set_permissions(user, read_messages=False, send_messages=False, add_reactions=False, create_public_threads=False, create_private_threads=False)
         print("Successfully removed ", user, " from ", channel_name)
         return True
     except Exception as e:


### PR DESCRIPTION
This try to fix #173, instead of adding new role, we already have functions to set permissions for each player.
So we will just reuse that function with adding new `add_reactions` permission