### PR TITLE
Fix player roles are in the same order with display roles, add total players in leaderboard

### DIFF
--- a/game/__init__.py
+++ b/game/__init__.py
@@ -208,9 +208,11 @@ class Game:
             game_role = map(lambda role: role if role != 'Cupid' else 'Villager', game_role)
             # print("DEBUG----", game_role)
 
+        # To make sure player roles and display roles are not in the same order
+        assigning_roles = random.sample(game_role, len(game_role))
         r = {
             id_: roles.get_role_type(role_name)(interface, id_, names_dict[id_])
-            for id_, role_name in zip(ids, game_role)
+            for id_, role_name in zip(ids, assigning_roles)
         }
         print("Player list:", r)
         return r

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -209,7 +209,9 @@ class Game:
             # print("DEBUG----", game_role)
 
         # To make sure player roles and display roles are not in the same order
-        assigning_roles = random.sample(game_role, len(game_role))
+        sample_times = 5
+        for _ in range(sample_times):
+            assigning_roles = random.sample(game_role, len(game_role))
         r = {
             id_: roles.get_role_type(role_name)(interface, id_, names_dict[id_])
             for id_, role_name in zip(ids, assigning_roles)
@@ -629,7 +631,8 @@ class Game:
                     text_template.generate_reveal_str_list(reveal_list, game_winner, self.cupid_dict),
                     [" x ".join(f"<@{player_id}>" for player_id in self.cupid_dict)] if self.cupid_dict else []
                 ],
-                start_time_str=self.start_time.strftime(text_templates.get_format_string("datetime"))
+                start_time_str=self.start_time.strftime(text_templates.get_format_string("datetime")),
+                total_players=len(self.players)
             )
             await self.interface.send_embed_to_channel(game_result, config.LEADERBOARD_CHANNEL)
 

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -1235,13 +1235,13 @@
     }
   },
   "game_result_embed": {
-    "params": ["start_time_str"],
+    "params": ["start_time_str", "total_players"],
     "color": "0xfabe4e",
     "template": {
       "vi": {
         "title": "Kết quả trò chơi",
         "description": "Trò chơi đã bắt đầu lúc {start_time_str}.",
-        "content_headers": ["Số ngày đã trải qua", "\u200B\n🏆 Phe chiến thắng", "\u200B\n📝 Danh sách người chơi", "💘 Cặp đôi vàng"]
+        "content_headers": ["Số ngày đã trải qua", "\u200B\n🏆 Phe chiến thắng", "\u200B\n📝 Danh sách {total_players} người chơi", "💘 Cặp đôi vàng"]
       },
       "en": {
         "title": "Game result",


### PR DESCRIPTION
- Fixed #194 
- Don't need to randomize the display role list
- Added total players in leaderboard