### PR TITLE
fix: temporary enhance role generator

### DIFF
--- a/commands/player.py
+++ b/commands/player.py
@@ -24,6 +24,9 @@ def check_vote_valid(num_votes, num_players, task_name):
 async def do_join(game, message, force=False):
     """Join game"""
     if not game.is_started():
+        if len(game.players) >= config.MAXIMUM_PLAYERS:
+            await message.reply(text_templates.generate_text("maximum_players_exceeded", maximum_players=config.MAXIMUM_PLAYERS))
+            return
         if force:
             user_list = message.mentions
             if not user_list:

--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ VOTE_RATE = 0.5     # 50%
 DAYTIME = 240       # 60s
 NIGHTTIME = 60      # 30s
 ALERT_PERIOD = 30   # 20s
+MAXIMUM_PLAYERS = 20
 
 
 """ Non-configurable value """

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -12,55 +12,65 @@ delta = generator_info['delta']
 def get_score(generated_roles):
     return sum(role_dict[r] for r in generated_roles)
 
-def add_additional_roles(role_list, num_of_players):
+
+def add_additional_roles(role_list, remaining_roles):
     ignored_roles = ["Werewolf", "Seer", "Guard", "Villager", "Lycan"]
     # From lowest to highest score roles
-    fixed_additional_roles = sorted([role for role, score in role_dict.items() if role not in ignored_roles], key=lambda x: role_dict[x])
-    additional_roles = [role for role in fixed_additional_roles if role not in role_list[:num_of_players]]
+    fixed_additional_roles = sorted([role for role in role_dict.keys() if role not in ignored_roles], key=lambda x: role_dict[x])
+    additional_roles = [role for role in fixed_additional_roles if role not in role_list[:remaining_roles]]
     lycan_amount = role_list.count("Lycan")
 
     # Replace boring Villager/Lycan
     for role in additional_roles:
-        for i in range(num_of_players):
-            if (role_list[i] == "Villager") or (role_list[i] == "Lycan" and lycan_amount > 2): # 2 Lycans are enough fun
+        for i in range(remaining_roles):
+            if (role_list[i] == "Villager") or (role_list[i] == "Lycan" and lycan_amount > 2):  # 2 Lycans are enough fun
                 role_list[i] = role
                 break
 
     return role_list
 
+
+def balance_werewolves(total_players, role_list, remaining_roles):
+    total_wolves = sum(r in ("Werewolf", "Superwolf") for r in role_list[:remaining_roles]) + 1
+    while total_wolves > 4 or \
+            (total_players <= 8 and total_wolves > 2) or \
+            (total_players <= 6 and total_wolves >= 2):
+        if "Werewolf" in role_list[:remaining_roles]:
+            role_list.remove("Werewolf")
+        elif "Superwolf" in role_list[:remaining_roles]:
+            role_list.remove("Superwolf")
+        total_wolves -= 1
+
+    return role_list
+
+
 def generate_roles_new_strategy(ids):
-    num_of_players = len(ids)
+    total_players = len(ids)
 
     fixed_roles = ["Werewolf", "Seer", "Guard", "Villager"]
-    if num_of_players == 4:
+    if total_players == 4:
         return dict(Counter(fixed_roles))
 
     role_list = list(r for r in role_dict if r not in fixed_roles)
 
-    num_of_players = num_of_players - len(fixed_roles)
+    remaining_roles = total_players - len(fixed_roles)
 
-    while len(role_list) < num_of_players * 2:
+    while len(role_list) < remaining_roles * 2:
         role_list += ["Werewolf", "Lycan"] + ["Villager"] * 2
 
     random.shuffle(role_list)
 
-    scores = abs(get_score(fixed_roles + role_list[:num_of_players]))
+    scores = abs(get_score(fixed_roles + role_list[:remaining_roles]))
 
     while scores > delta:
         random.shuffle(role_list)
-        scores = get_score(fixed_roles + role_list[:num_of_players])
+        scores = get_score(fixed_roles + role_list[:remaining_roles])
 
-    if num_of_players >= 3:
+    if total_players >= 7:
         # Handle boring & useless Villagers :D
-        role_list = add_additional_roles(role_list, num_of_players)
-
-    total_players = len(ids)
-    total_wolves = role_list[:num_of_players].count("Werewolf") + role_list[:num_of_players].count("Superwolf") + 1
+        role_list = add_additional_roles(role_list, remaining_roles)
 
     # Limit werewolves
-    while (total_wolves > 4) or (total_players <= 9 and total_wolves > 2) or (total_players <= 7 and total_wolves >= 2):
-        if "Werewolf" in role_list[:num_of_players]:
-            role_list.remove("Werewolf")
-        total_wolves -= 1
+    role_list = balance_werewolves(total_players, role_list, remaining_roles)
 
-    return dict(Counter(fixed_roles + role_list[:num_of_players]))
+    return dict(Counter(fixed_roles + role_list[:remaining_roles]))

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -13,8 +13,9 @@ def get_score(generated_roles):
     return sum(role_dict[r] for r in generated_roles)
 
 def add_additional_roles(role_list, num_of_players):
+    ignored_roles = ["Werewolf", "Seer", "Guard", "Villager", "Lycan"]
     # From lowest to highest score roles
-    fixed_additional_roles = ["Superwolf", "Cupid", "Betrayer", "Fox", "Tanner", "Chief", "Zombie", "Hunter", "Witch"]
+    fixed_additional_roles = sorted([role for role, score in role_dict.items() if role not in ignored_roles], key=lambda x: role_dict[x])
     additional_roles = [role for role in fixed_additional_roles if role not in role_list[:num_of_players]]
     lycan_amount = role_list.count("Lycan")
 
@@ -49,8 +50,17 @@ def generate_roles_new_strategy(ids):
         random.shuffle(role_list)
         scores = get_score(fixed_roles + role_list[:num_of_players])
 
-    if num_of_players >= 7:
+    if num_of_players >= 3:
         # Handle boring & useless Villagers :D
         role_list = add_additional_roles(role_list, num_of_players)
+
+    total_players = len(ids)
+    total_wolves = role_list[:num_of_players].count("Werewolf") + role_list[:num_of_players].count("Superwolf") + 1
+
+    # Limit werewolves
+    while (total_wolves > 5) or (total_players <= 9 and total_wolves > 2) or (total_players <= 7 and total_wolves >= 2):
+        if "Werewolf" in role_list[:num_of_players]:
+            role_list.remove("Werewolf")
+        total_wolves -= 1
 
     return dict(Counter(fixed_roles + role_list[:num_of_players]))

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -12,6 +12,19 @@ delta = generator_info['delta']
 def get_score(generated_roles):
     return sum(role_dict[r] for r in generated_roles)
 
+def add_additional_roles(role_list, num_of_players):
+    # From lowest to highest score roles
+    fixed_additional_roles = ["Superwolf", "Cupid", "Betrayer", "Fox", "Tanner", "Chief", "Zombie", "Hunter", "Witch"]
+    additional_roles = [role for role in fixed_additional_roles if role not in role_list[:num_of_players]]
+
+    # Replace boring Villager
+    for role in additional_roles:
+        for i in range(num_of_players):
+            if role_list[i] == "Villager":
+                role_list[i] = role
+                break
+
+    return role_list
 
 def generate_roles_new_strategy(ids):
     num_of_players = len(ids)
@@ -31,7 +44,11 @@ def generate_roles_new_strategy(ids):
 
     scores = abs(get_score(fixed_roles + role_list[:num_of_players]))
 
-    while scores < delta or scores > 7:
+    while scores > delta:
         random.shuffle(role_list)
         scores = get_score(fixed_roles + role_list[:num_of_players])
+
+    # Handle boring & useless Villagers :D
+    role_list = add_additional_roles(role_list, num_of_players)
+
     return dict(Counter(fixed_roles + role_list[:num_of_players]))

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -16,11 +16,12 @@ def add_additional_roles(role_list, num_of_players):
     # From lowest to highest score roles
     fixed_additional_roles = ["Superwolf", "Cupid", "Betrayer", "Fox", "Tanner", "Chief", "Zombie", "Hunter", "Witch"]
     additional_roles = [role for role in fixed_additional_roles if role not in role_list[:num_of_players]]
+    lycan_amount = role_list.count("Lycan")
 
-    # Replace boring Villager
+    # Replace boring Villager/Lycan
     for role in additional_roles:
         for i in range(num_of_players):
-            if role_list[i] == "Villager":
+            if (role_list[i] == "Villager") or (role_list[i] == "Lycan" and lycan_amount > 2): # 2 Lycans are enough fun
                 role_list[i] = role
                 break
 
@@ -29,7 +30,7 @@ def add_additional_roles(role_list, num_of_players):
 def generate_roles_new_strategy(ids):
     num_of_players = len(ids)
 
-    fixed_roles = ['Werewolf', 'Seer', 'Guard', 'Villager']
+    fixed_roles = ["Werewolf", "Seer", "Guard", "Villager"]
     if num_of_players == 4:
         return dict(Counter(fixed_roles))
 
@@ -38,7 +39,7 @@ def generate_roles_new_strategy(ids):
     num_of_players = num_of_players - len(fixed_roles)
 
     while len(role_list) < num_of_players * 2:
-        role_list += ['Werewolf', 'Lycan'] + ['Villager'] * 2
+        role_list += ["Werewolf", "Lycan"] + ["Villager"] * 2
 
     random.shuffle(role_list)
 
@@ -48,7 +49,8 @@ def generate_roles_new_strategy(ids):
         random.shuffle(role_list)
         scores = get_score(fixed_roles + role_list[:num_of_players])
 
-    # Handle boring & useless Villagers :D
-    role_list = add_additional_roles(role_list, num_of_players)
+    if num_of_players >= 7:
+        # Handle boring & useless Villagers :D
+        role_list = add_additional_roles(role_list, num_of_players)
 
     return dict(Counter(fixed_roles + role_list[:num_of_players]))

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -58,7 +58,7 @@ def generate_roles_new_strategy(ids):
     total_wolves = role_list[:num_of_players].count("Werewolf") + role_list[:num_of_players].count("Superwolf") + 1
 
     # Limit werewolves
-    while (total_wolves > 5) or (total_players <= 9 and total_wolves > 2) or (total_players <= 7 and total_wolves >= 2):
+    while (total_wolves > 4) or (total_players <= 9 and total_wolves > 2) or (total_players <= 7 and total_wolves >= 2):
         if "Werewolf" in role_list[:num_of_players]:
             role_list.remove("Werewolf")
         total_wolves -= 1

--- a/game/generate_roles.py
+++ b/game/generate_roles.py
@@ -33,8 +33,9 @@ def add_additional_roles(role_list, remaining_roles):
 def balance_werewolves(total_players, role_list, remaining_roles):
     total_wolves = sum(r in ("Werewolf", "Superwolf") for r in role_list[:remaining_roles]) + 1
     while total_wolves > 4 or \
-            (total_players <= 8 and total_wolves > 2) or \
-            (total_players <= 6 and total_wolves >= 2):
+            (10 <= total_players <= 14 and total_wolves > 3) or \
+            (total_players <= 9 and total_wolves > 2) or \
+            (total_players <= 6 and total_wolves > 1):
         if "Werewolf" in role_list[:remaining_roles]:
             role_list.remove("Werewolf")
         elif "Superwolf" in role_list[:remaining_roles]:

--- a/json/role_generator_info.json
+++ b/json/role_generator_info.json
@@ -15,5 +15,5 @@
     "Werewolf": -5,
     "Superwolf": -6
   },
-  "delta": 5
+  "delta": 0
 }

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -831,6 +831,13 @@
       "en": ["You are not currently in the game."]
     }
   },
+  "maximum_players_exceeded": {
+    "params": ["maximum_players"],
+    "template": {
+      "vi": ["Rất tiếc, trò chơi chỉ giới hạn cho {maximum_players} người :v"],
+      "en": ["Sorry, the game is limited to {maximum_players} players :v"]
+    }
+  },
   "already_in_game_text": {
     "params": [],
     "template": {


### PR DESCRIPTION
Current idea:

- Set `delta` to 0.
- While `scores >  delta`, keep shuffling
- Fixed additional roles are the roles that may not appear, ordering from lowest to highest score
`["Superwolf", "Cupid", "Betrayer", "Fox", "Tanner", "Chief", "Zombie", "Hunter", "Witch"]`
- Added limit werewolves
- Limit to maximum 20 players

The evil side may be stronger but then we replace useless `Villager` with others powerful role, works best for many players game

Delta can be adjusted to higher `> 0` if the evil side is too strong

