### PR TITLE
Fix using commands out of action time

### DIFF
--- a/game/__init__.py
+++ b/game/__init__.py
@@ -1250,7 +1250,7 @@ class Game:
         # pylint: disable=too-many-return-statements, too-many-branches
         if not self.__is_on_phase:
             return text_templates.generate_text(
-                "not_in_phase_text",
+                "not_in_phase_action_time_text",
                 phase=text_templates.get_word_in_language(str(self.game_phase))
             )
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -72,6 +72,7 @@ class Game:
         self.play_time_start = datetime.time(0, 0, 0)  # in UTC
         self.play_time_end = datetime.time(0, 0, 0)  # in UTC
         self.play_zone = "UTC+7"
+        self.__is_on_phase = False
         self.async_lock = asyncio.Lock()
         self.reset_game_state()  # Init other game variables every end game.
         self.database = Database().create_instance()
@@ -700,6 +701,7 @@ class Game:
 
                 # New phase
                 await self.new_phase()
+                self.__is_on_phase = True
 
                 await asyncio.gather(*[role.on_phase(self.game_phase) for role in self.get_alive_players()])
 
@@ -712,6 +714,7 @@ class Game:
                 self.next_flag.clear()
                 print("After clear")
 
+                self.__is_on_phase = False
                 await self.end_phase()
                 # End_phase
 
@@ -860,6 +863,9 @@ class Game:
             await self.control_muting_party_channel(config.WEREWOLF_CHANNEL, True, self.get_werewolf_list())
             await self.control_muting_party_channel(config.COUPLE_CHANNEL, True, list(self.cupid_dict.keys()))
             await self.control_muting_party_channel(config.GAMEPLAY_CHANNEL, False, list(self.players.keys()))
+
+            # init object
+            self.voter_dict = {}
         else:
             print("Error no player in game.")
             await self.stop()
@@ -930,6 +936,11 @@ class Game:
             await asyncio.gather(*[
                 player.on_night_start(alive_embed_data, dead_embed_data) for player in self.get_all_players()
             ])
+
+            # init object
+            self.wolf_kill_dict = {}
+            self.night_pending_kill_list = []
+            self.reborn_set = set()
 
     async def werewolf_do_new_nighttime_phase(self, alive_embed_data):
         if self.modes.get("new_moon", False) and self.new_moon_mode.current_event == NewMoonMode.FULL_MOON_VEGETARIAN:
@@ -1237,6 +1248,12 @@ class Game:
     async def do_player_action(self, cmd, author_id, *targets_id):
         # FIXME
         # pylint: disable=too-many-return-statements, too-many-branches
+        if not self.__is_on_phase:
+            return text_templates.generate_text(
+                "not_in_phase_text",
+                phase=text_templates.get_word_in_language(str(self.game_phase))
+            )
+
         assert self.players is not None
         # print(self.players)
         author = self.players.get(author_id)
@@ -1280,6 +1297,7 @@ class Game:
 
         return text_template.generate_invalid_command_text(cmd)
 
+    @command_verify_phase(const.GamePhase.DAY)
     async def vote(self, author, target):
         author_id = author.player_id
         target_id = target.player_id

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -844,6 +844,9 @@ class Game:
         self.day += 1
 
         if self.players:
+            await asyncio.gather(*[
+                player.on_day_start(self.day) for player in self.get_all_players()
+            ])
             await self.interface.send_action_text_to_channel("day_phase_beginning_text", config.GAMEPLAY_CHANNEL, day=self.day)
             embed_data = self.generate_player_list_embed()
             await self.interface.send_embed_to_channel(embed_data, config.GAMEPLAY_CHANNEL)
@@ -855,9 +858,6 @@ class Game:
                 alive_players_embed_data = self.generate_player_list_embed(True)
                 await self.new_moon_mode.do_new_daytime_phase(self.interface, alive_players_embed_data=alive_players_embed_data)
 
-            await asyncio.gather(*[
-                player.on_day_start(self.day) for player in self.get_all_players()
-            ])
             # Mute all party channels
             # Unmute all alive players in config.GAMEPLAY_CHANNEL
             await self.control_muting_party_channel(config.WEREWOLF_CHANNEL, True, self.get_werewolf_list())

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -1120,13 +1120,12 @@ class Game:
         print(self.display_alive_player())
         if self.timer_enable:
             await self.cancel_running_task(self.task_run_timer_phase)
-
-            if self.game_phase == const.GamePhase.DAY:
-                await self.do_new_daytime_phase()
-            elif self.game_phase == const.GamePhase.NIGHT:
-                await self.do_new_nighttime_phase()
-
             self.task_run_timer_phase = asyncio.create_task(self.run_timer_phase(), name="task_run_timer_phase")
+
+        if self.game_phase == const.GamePhase.DAY:
+            await self.do_new_daytime_phase()
+        elif self.game_phase == const.GamePhase.NIGHT:
+            await self.do_new_nighttime_phase()
 
     async def end_phase(self):
         assert self.game_phase != const.GamePhase.NEW_GAME

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -664,13 +664,6 @@
       "en": ["You can only use your skill once!"]
     }
   },
-  "invalid_punish_in_cemetery_text": {
-    "params": [],
-    "template": {
-      "vi": ["Chỉ sử dụng trong buổi sáng của sự kiện new moon **Trừng Phạt**!"],
-      "en": ["Only use in the morning of new moon event **Punishment**!"]
-    }
-  },
   "inform_power_used_text": {
     "params": [],
     "template": {
@@ -786,6 +779,13 @@
     "template": {
       "vi": ["Ráng đợi tới {phase} bạn êy!"],
       "en": ["Please wait until the {phase}, my friend!"]
+    }
+  },
+  "invalid_phase_in_event_text": {
+    "params": ["phase", "event"],
+    "template": {
+      "vi": ["Chỉ sử dụng trong thời gian {phase} của sự kiện new moon **{event}**!"],
+      "en": ["Only use in the {phase} of new moon event **{event}**!"]
     }
   },
   "invalid_author_disabled_action_text": {

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -872,7 +872,7 @@
       "en": ["You are not currently in the game."]
     }
   },
-  "not_in_phase_text": {
+  "not_in_phase_action_time_text": {
     "params": ["phase"],
     "template": {
       "vi": ["Hiện đang ngoài giờ thực hiện chức năng {phase}."],

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -788,13 +788,6 @@
       "en": ["Please wait until the {phase}, my friend!"]
     }
   },
-  "invalid_phase_in_event_text": {
-    "params": ["phase", "event"],
-    "template": {
-      "vi": ["Chỉ sử dụng trong thời gian {phase} của sự kiện new moon **{event}**!"],
-      "en": ["Only use in the {phase} of new moon event **{event}**!"]
-    }
-  },
   "invalid_author_disabled_action_text": {
     "params": [],
     "template": {

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -543,19 +543,6 @@
       "en": ["🩸 You have cursed {target}"]
     }
   },
-  "zombie_before_voting_text": {
-    "params": [],
-    "template": {
-      "vi": [
-        "🧟 Bạn có thể đội mồ sống dậy! Bạn chỉ có thể sử dụng kỹ năng này 1 lần.",
-        "💡 Nhập `{bot_prefix}zombie` để trở lại cuộc đời.\n"
-      ],
-      "en": [
-        "🧟 You can be reborn! You can only use this skill once.",
-        "💡 Enter `{bot_prefix}zombie` to return to the life.\n"
-      ]
-    }
-  },
   "pathologist_before_voting_text": {
     "params": [],
     "template": {
@@ -575,6 +562,19 @@
     "template": {
       "vi": ["🧬 Ồ, bạn đã khám nghiệm được {target} là {role}."],
       "en": ["🧬 Oh, you've examined {target} is a {role}."]
+    }
+  },
+  "zombie_before_voting_text": {
+    "params": [],
+    "template": {
+      "vi": [
+        "🧟 Bạn có thể đội mồ sống dậy! Bạn chỉ có thể sử dụng kỹ năng này 1 lần.",
+        "💡 Nhập `{bot_prefix}zombie` để trở lại cuộc đời.\n"
+      ],
+      "en": [
+        "🧟 You can be reborn! You can only use this skill once.",
+        "💡 Enter `{bot_prefix}zombie` to return to the life.\n"
+      ]
     }
   },
   "zombie_after_reborn_text": {
@@ -863,6 +863,13 @@
     "template": {
       "vi": ["Hiện bạn đang không ở trong game."],
       "en": ["You are not currently in the game."]
+    }
+  },
+  "not_in_phase_text": {
+    "params": ["phase"],
+    "template": {
+      "vi": ["Hiện đang ngoài giờ thực hiện chức năng {phase}."],
+      "en": ["You are not currently in the {phase} action time."]
     }
   },
   "maximum_players_exceeded": {

--- a/json/text_template.json
+++ b/json/text_template.json
@@ -664,6 +664,13 @@
       "en": ["You can only use your skill once!"]
     }
   },
+  "invalid_punish_in_cemetery_text": {
+    "params": [],
+    "template": {
+      "vi": ["Chỉ sử dụng trong buổi sáng của sự kiện new moon **Trừng Phạt**!"],
+      "en": ["Only use in the morning of new moon event **Punishment**!"]
+    }
+  },
   "inform_power_used_text": {
     "params": [],
     "template": {


### PR DESCRIPTION
After timer ends or before timer starts, a player can rapidly use a command.

So it cause a bug on day phase: 
- timer ends
- a player use `vote` command
- the vote will be registered as the vote on the next day phase.

![image-2](https://github.com/dnh-bot/dnh-werewolf-bot/assets/19959482/45ab69c0-99ab-42f5-8088-1144bec3d5bb)

![image-3](https://github.com/dnh-bot/dnh-werewolf-bot/assets/19959482/92c3cf58-7d68-46df-98eb-f88d1eeeb45e)
